### PR TITLE
Adding the rpitx-ui symlink creation process to the installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ cd rpitx
 ./install.sh
 ```
 
-Create a symbolic link to _easytest.sh_ to be able to run _easytest.sh_ from anywhere on the system by running the **rpitx-ui** command.
-```sh
-sudo ln -s "$PWD/easytest.sh" /usr/local/bin/rpitx-ui
-```
-
 Make a reboot in order to use **rpitx-ui** in a stable state.
 ```sh
 sudo reboot

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ LINE='force_turbo=1'
 grep -qF "$LINE" "$FILE"  || echo "$LINE" | sudo tee --append "$FILE"
 
 sudo ln -s "$PWD/easytest.sh" /usr/local/bin/rpitx-ui
-echo "$(tput setaf 3)[INFO]$(tput sgr0): Symbolic link created! You can now use the rpitx-ui command to run the application.."
+echo "$(tput setaf 3)[INFO]$(tput sgr0): Symbolic link created! You can now use the rpitx-ui command to run the application."
 
 echo "$(tput setaf 2)Installation completed!"
 

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,10 @@ grep -qF "$LINE" "$FILE"  || echo "$LINE" | sudo tee --append "$FILE"
 #PI4
 LINE='force_turbo=1'
 grep -qF "$LINE" "$FILE"  || echo "$LINE" | sudo tee --append "$FILE"
+
+sudo ln -s "$PWD/easytest.sh" /usr/local/bin/rpitx-ui
+echo "$(tput setaf 3)[INFO]$(tput sgr0): Symbolic link created! You can now use the rpitx-ui command to run the application.."
+
 echo "$(tput setaf 2)Installation completed!"
 
 echo "$(tput setaf 3)[ACTION REQUIRED]$(tput sgr0): A reboot is required to complete the installation!"
@@ -51,7 +55,7 @@ read -p "Execute now? (y/n): " choice
 # Check the user's choice
 if [ "$choice" = "y" ] || [ "$choice" = "Y" ]; then
   echo "$(tput setaf 3)[INFO]$(tput sgr0) Rebooting now..."
-  sudo reboot  # You may need to run this with sudo privileges
+  sudo reboot
 else
   echo "$(tput setaf 3)[INFO]$(tput sgr0) Reboot canceled."
 fi


### PR DESCRIPTION
There is no longer a need to run the command "_sudo ln -s "$PWD/easytest.sh" /usr/local/bin/rpitx-ui_" - it is executed automatically during the installation process.