### PR TITLE
Fix frequency multiplier in easytest.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 # About rpitx-ui
 **rpitx** is a general radio frequency SDR transmitter for Raspberry Pi which can work on frequencies from **5 kHz** up to **1500 MHz**. **rpitx-ui** includes changes to the _./easytest.sh_ script to make it easier to interact with the **rpitx** package via a console user interface.
 
+> [!WARNING]
+>Current version of **[rpitx](https://github.com/F5OEO/rpitx)** package in the original repository has a _dvb/dvbsenco8.s_ build error! Current version of **rpitx-ui** is based on rpitx commit cce1fe6acf90d4d344d34ce304aed48fe80ec4ff51e7 and has no build errors.
+
 # Installation process
 Update the list of available software packages, download and install **rpitx-ui** package:
 ```sh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **rpitx** is a general radio frequency SDR transmitter for Raspberry Pi which can work on frequencies from **5 kHz** up to **1500 MHz**. **rpitx-ui** includes changes to the _./easytest.sh_ script to make it easier to interact with the **rpitx** package via a console user interface.
 
 > [!WARNING]
->Current version of **[rpitx](https://github.com/F5OEO/rpitx)** package in the original repository has a _dvb/dvbsenco8.s_ build error! Current version of **rpitx-ui** is based on rpitx commit cce1fe6acf90d4d344d34ce304aed48fe80ec4ff51e7 and has no build errors.
+>Current version of **[rpitx](https://github.com/F5OEO/rpitx)** package in the original repository has a _dvb/dvbsenco8.s_ build error! Current version of **rpitx-ui** is based on rpitx commit [cce1fe6](https://github.com/F5OEO/rpitx/commit/cce1fe6acf90d4d34ce304aed48fe80ec4ff51e7) and has no build errors.
 
 # Installation process
 Update the list of available software packages, download and install **rpitx-ui** package:

--- a/easytest.sh
+++ b/easytest.sh
@@ -191,7 +191,7 @@ do_freq_setup
 			
 			5\ *) do_file_choose ".wav (16 bit per sample, 48000 sample rate, mono)" "$RESOURCES_LOCATION" ".wav"
 			if [ $abort_action -eq 0 ]; then
-				"./testnfm.sh" "$OUTPUT_FREQ""e3" "$FILE_LOC" >/dev/null 2>/dev/null &
+				"./testnfm.sh" "$OUTPUT_FREQ""e6" "$FILE_LOC" >/dev/null 2>/dev/null &
 				do_status
 			fi
 			;;
@@ -205,7 +205,7 @@ do_freq_setup
 			
 			7\ *) do_file_choose ".wav (16 bit per sample, 48000 sample rate, mono)" "$RESOURCES_LOCATION" ".wav"
 			if [ $abort_action -eq 0 ]; then
-				"./testam.sh" "$OUTPUT_FREQ""e3" "$FILE_LOC" >/dev/null 2>/dev/null &
+				"./testam.sh" "$OUTPUT_FREQ""e6" "$FILE_LOC" >/dev/null 2>/dev/null &
 				do_status
 			fi
 			;;


### PR DESCRIPTION
Fix incorrect frequency multiplier in _easytest.sh_ script. Previously incorrect frequency multiplier "e3" was used in **_testnfm_** and **_testam_** modules. Changed to "e6".

Added information about build errors in the latest version of the original **rpitx** package.