### PR TITLE
[Bugfix] Fixing the project build error on Debian GNU/Linux 13 (Trixie)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,14 @@ cd ../ || exit
 cd src || exit
 git clone https://github.com/F5OEO/librpitx
 cd librpitx/src || exit
-make && sudo make install
+make
+if ! sudo make install 2>/dev/null; then
+  echo "$(tput setaf 3)[INFO]$(tput sgr0): librpitx shared library build failed (missing libbcm_host), installing static library and headers manually..."
+  sudo install -m 0644 librpitx.a /usr/local/lib/librpitx.a
+  sudo mkdir -p /usr/local/include/librpitx
+  sudo cp *.h /usr/local/include/librpitx/
+  sudo ldconfig
+fi
 cd ../../ || exit
 
 cd pift8

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ grep -qF "$LINE" "$FILE"  || echo "$LINE" | sudo tee --append "$FILE"
 LINE='force_turbo=1'
 grep -qF "$LINE" "$FILE"  || echo "$LINE" | sudo tee --append "$FILE"
 
-sudo ln -s "$PWD/easytest.sh" /usr/local/bin/rpitx-ui
+sudo ln -sf "$PWD/easytest.sh" /usr/local/bin/rpitx-ui
 echo "$(tput setaf 3)[INFO]$(tput sgr0): Symbolic link created! You can now use the rpitx-ui command to run the application."
 
 echo "$(tput setaf 2)Installation completed!"

--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,14 @@ cd ../ || exit
 cd src || exit
 git clone https://github.com/F5OEO/librpitx
 cd librpitx/src || exit
-make
-if ! sudo make install 2>/dev/null; then
-  echo "$(tput setaf 3)[INFO]$(tput sgr0): librpitx shared library build failed (missing libbcm_host), installing static library and headers manually..."
-  sudo install -m 0644 librpitx.a /usr/local/lib/librpitx.a
+if ldconfig -p | grep -q libbcm_host; then
+  make && sudo make install
+else
+  echo "$(tput setaf 3)[INFO]$(tput sgr0): libbcm_host not found, building librpitx as static library only..."
+  make librpitx.a
   sudo mkdir -p /usr/local/include/librpitx
   sudo cp *.h /usr/local/include/librpitx/
+  sudo install -m 0644 librpitx.a /usr/local/lib/librpitx.a
   sudo ldconfig
 fi
 cd ../../ || exit

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,15 @@ all: ../pisstv ../piopera ../pifsq ../pichirp ../sendiq ../tune ../freedv ../poc
 
 CFLAGS	?= -Wall -g -O2 -Wno-unused-variable
 CXXFLAGS ?= -std=c++11 -Wall -g -O2 -Wno-unused-variable
-LDFLAGS ?= -L/opt/vc/lib
+
+# Auto-detect library path: use /opt/vc/lib if available, otherwise /usr/local/lib
+ifneq ($(wildcard /opt/vc/lib/librpitx*),)
+  RPITX_LIBDIR = /opt/vc/lib
+else
+  RPITX_LIBDIR = /usr/local/lib
+endif
+
+LDFLAGS ?= -L$(RPITX_LIBDIR)
 LDFLAGS += -lrpitx -lm -lrt -lpthread
 CXX ?= c++
 CC ?= cc
@@ -63,7 +71,7 @@ LDFLAGS_Pissb	= $(LDFLAGS) -lsndfile -lliquid
 	$(CC) $(CFLAGS) -c -o pifmrds/rds_wav.o pifmrds/rds_wav.c
 	$(CC) $(CFLAGS) -c -o pifmrds/fm_mpx.o pifmrds/fm_mpx.c
 	$(CC) -o pifmrds/rds_wav pifmrds/rds_wav.o pifmrds/rds.o pifmrds/waveforms.o pifmrds/fm_mpx.o -lm -lsndfile
-	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../pifmrds pifmrds/rds.o pifmrds/waveforms.o pifmrds/pi_fm_rds.cpp pifmrds/fm_mpx.o pifmrds/control_pipe.o -lm -lsndfile -lrt -lpthread -L/opt/vc/lib -lrpitx
+	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../pifmrds pifmrds/rds.o pifmrds/waveforms.o pifmrds/pi_fm_rds.cpp pifmrds/fm_mpx.o pifmrds/control_pipe.o -lm -lsndfile -lrt -lpthread -L$(RPITX_LIBDIR) -lrpitx
 
 ../rpitx: rpitxv1/rpitx.cpp 
 	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../rpitx rpitxv1/rpitx.cpp $(LDFLAGS)


### PR DESCRIPTION
### Problem description
On **Debian Trixie-based Raspberry Pi OS**, `libbcm_host` and the `libraspberrypi-dev` package are no longer available. The librpitx Makefile requires `-lbcm_host` to build the shared library, so make install fails and neither the headers nor the library get installed to system paths. This causes all downstream targets to fail with `librpitx/librpitx.h: No such file or directory`. The issue has been confirmed on **Raspberry Pi 3** and **4B**.

The error that occurs:
```bash
g++ -std=c++14 -I.   -c -o pift8.o pift8.cpp
pift8.cpp:13:10: fatal error: librpitx/librpitx.h: No such file or directory
   13 | #include <librpitx/librpitx.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [<builtin>: pift8.o] Error 1
g++ -std=c++11 -Wall -g -O2 -Wno-unused-variable -o ../pisstv sstv/pisstv.cpp  -L/opt/vc/lib -lrpitx -lm -lrt -lpthread
sstv/pisstv.cpp:18:10: fatal error: librpitx/librpitx.h: No such file or directory
   18 | #include <librpitx/librpitx.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:17: ../pisstv] Error 1
g++ -std=c++11 -Wall -g -O2 -Wno-unused-variable -o ../pisstv sstv/pisstv.cpp  -L/opt/vc/lib -lrpitx -lm -lrt -lpthread
sstv/pisstv.cpp:18:10: fatal error: librpitx/librpitx.h: No such file or directory
   18 | #include <librpitx/librpitx.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:17: ../pisstv] Error 1
```

### Fix description
- **install.sh**: Detect missing `libbcm_host` before building librpitx. If absent, build only the static library `librpitx.a` and install it with headers manually to `/usr/local/lib` and `/usr/local/include/librpitx/`.
- **src/Makefile**: Replace hardcoded `-L/opt/vc/lib` with auto-detection - use `/opt/vc/lib` if librpitx is present there, otherwise fall back to `/usr/local/lib`. Also fixed the same hardcoded path in the `pifmrds` build rule.

### Test results
Project [build results](https://gist.github.com/IgrikXD/8691cf962866cafade7b2512845dec82) after fixing the error.