### PR TITLE
[GitHub Actions] Fix workflow name in GitHub Actions configuration

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -1,4 +1,4 @@
-name: rpitx-ui Build & Install Test
+name: rpitx-ui build
 
 on:
   push:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for the `rpitx-ui` project. The workflow name has been changed from "rpitx-ui Build & Install Test" to "rpitx-ui build" for clarity and consistency.