### PR TITLE
[GitHub Actions] Update workflow name and ensure git is installed during rpitx-ui installation

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: Build & Test on Raspberry Pi OS 64-bit
+    name: Build on latest Raspberry Pi OS 64-bit
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -53,6 +53,7 @@ jobs:
             # 1. Install rpitx-ui
             # ==============================================================
             echo "::group::Install rpitx-ui"
+            sudo apt-get update && sudo apt-get install -y git
             echo "n" | bash ./install.sh
             echo "::endgroup::"
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building the project on Raspberry Pi OS 64-bit. The main changes focus on improving build reliability by ensuring necessary dependencies are installed and clarifying the job name.

Workflow improvements:

* Changed the job name in `.github/workflows/rpitx-ui-build.yml` to "Build on latest Raspberry Pi OS 64-bit" for clarity.
* Added a step to install `git` before running the install script to prevent potential failures due to missing dependencies.