### PR TITLE
[GitHub Actions] Update shell configuration and remove swap setup from build process

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           base_image: raspios_lite_arm64:latest
           cpu: cortex-a72
+          shell: /bin/bash
           image_additional_mb: 4096
           commands: |
             set -eu
@@ -48,22 +49,12 @@ jobs:
             cat /etc/os-release
             echo "::endgroup::"
 
-            echo "::group::Setup swap"
-            sudo fallocate -l 1G /swapfile
-            sudo chmod 600 /swapfile
-            sudo mkswap /swapfile
-            sudo swapon /swapfile
-            echo "PASS: 1 GB swap enabled"
-            echo "::endgroup::"
-
             # ==============================================================
             # 1. Install rpitx-ui
             # ==============================================================
             echo "::group::Install rpitx-ui"
             sudo apt-get update && sudo apt-get install -y git
             echo "n" | bash ./install.sh
-            sudo apt-get clean
-            sudo rm -rf /var/lib/apt/lists/*
             echo "::endgroup::"
 
             # ==============================================================


### PR DESCRIPTION
This pull request makes minor adjustments to the GitHub Actions workflow for building the `rpitx-ui` project. The main changes include specifying the shell for the build step and removing the swap setup and some cleanup commands.

Workflow improvements:

* Explicitly sets the shell to `/bin/bash` in the build job configuration to ensure consistent script execution.

Simplification and cleanup:

* Removes the swap file setup and related output, simplifying the build process and potentially reducing build time and complexity.
* Removes explicit `apt-get clean` and cache directory cleanup commands after installing dependencies.