### PR TITLE
Enhance uninstall process to remove third-party dependencies with --purge-deps flag

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -155,10 +155,11 @@ jobs:
             echo "::endgroup::"
 
             # ==============================================================
-            # 7. Uninstall rpitx-ui
+            # 7. Uninstall rpitx-ui (with --purge-deps to also remove
+            #    third-party dependencies and verify full cleanup)
             # ==============================================================
             echo "::group::Uninstall rpitx-ui"
-            echo "n" | bash ./uninstall.sh
+            echo "n" | bash ./uninstall.sh --purge-deps
             echo "::endgroup::"
 
             # ==============================================================


### PR DESCRIPTION
This pull request makes a minor update to the `rpitx-ui` uninstall step in the GitHub Actions workflow. The uninstall script is now run with the `--purge-deps` flag to ensure that third-party dependencies are also removed, improving the thoroughness of the cleanup process.

* Workflow improvement:
  * [`.github/workflows/rpitx-ui-build.yml`](diffhunk://#diff-8cecf18d6bb14312945d3d4a98a60700f23b2b37fd27c1218b169841873dc607L158-R162): Updated the uninstall command to use `--purge-deps`, ensuring all dependencies are removed during the uninstall step.