### PR TITLE
[Docs] Add author info, copyright and license headers to source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 27.03.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
 cmake_minimum_required(VERSION 3.25)
 project(rpitx-ui
     VERSION 1.4

--- a/scripts/testlsb.sh
+++ b/scripts/testlsb.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 27.03.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
 (while true; do cat "$2"; done) | pissb -l \
   | sudo sendiq -i /dev/stdin -s 48000 -f "$1" -t float

--- a/scripts/testusb.sh
+++ b/scripts/testusb.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 27.03.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
 (while true; do cat "$2"; done) | pissb -u \
   | sudo sendiq -i /dev/stdin -s 48000 -f "$1" -t float
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 27.03.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
 # Locate librpitx (installed to /usr/local/lib by install.sh)
 find_library(RPITX_LIBRARY
     NAMES rpitx

--- a/src/pissb/main.cpp
+++ b/src/pissb/main.cpp
@@ -8,6 +8,12 @@
  * @note Usage: pissb [-u | -l]
  *   - -u  Upper sideband (default)
  *   - -l  Lower sideband
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #include <unistd.h>

--- a/src/pissb/ssb_processor.cpp
+++ b/src/pissb/ssb_processor.cpp
@@ -1,6 +1,12 @@
 /**
  * @file ssb_processor.cpp
  * @brief SSB processor implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #include "ssb_processor.h"

--- a/src/pissb/ssb_processor.h
+++ b/src/pissb/ssb_processor.h
@@ -1,6 +1,12 @@
 /**
  * @file ssb_processor.h
  * @brief Single-sideband (SSB) modulation processor.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #pragma once

--- a/src/utils/agc.cpp
+++ b/src/utils/agc.cpp
@@ -1,6 +1,12 @@
 /**
  * @file agc.cpp
  * @brief AGC implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #include "agc.h"

--- a/src/utils/agc.h
+++ b/src/utils/agc.h
@@ -1,6 +1,12 @@
 /**
  * @file agc.h
  * @brief Fast automatic gain control (AGC) for IQ signals.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #pragma once

--- a/src/utils/biquad.cpp
+++ b/src/utils/biquad.cpp
@@ -1,6 +1,12 @@
 /**
  * @file biquad.cpp
  * @brief Biquad filter implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #include "biquad.h"

--- a/src/utils/biquad.h
+++ b/src/utils/biquad.h
@@ -1,6 +1,12 @@
 /**
  * @file biquad.h
  * @brief Second-order IIR (biquad) filter for audio signal processing.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #pragma once

--- a/src/utils/hilbert.cpp
+++ b/src/utils/hilbert.cpp
@@ -1,6 +1,12 @@
 /**
  * @file hilbert.cpp
  * @brief Hilbert transform FIR filter implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #include "hilbert.h"

--- a/src/utils/hilbert.h
+++ b/src/utils/hilbert.h
@@ -1,6 +1,12 @@
 /**
  * @file hilbert.h
  * @brief Hilbert transform FIR filter for analytic signal generation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #pragma once

--- a/src/utils/iq_sample.h
+++ b/src/utils/iq_sample.h
@@ -1,6 +1,12 @@
 /**
  * @file iq_sample.h
  * @brief In-phase / quadrature sample pair used throughout the DSP pipeline.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #pragma once

--- a/src/utils/wav_utils.cpp
+++ b/src/utils/wav_utils.cpp
@@ -1,6 +1,12 @@
 /**
  * @file wav_utils.cpp
  * @brief WAV header detection and I/O utility implementations.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #include "wav_utils.h"

--- a/src/utils/wav_utils.h
+++ b/src/utils/wav_utils.h
@@ -1,6 +1,12 @@
 /**
  * @file wav_utils.h
  * @brief WAV file header detection and low-level I/O utilities.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
 #pragma once


### PR DESCRIPTION
## Summary

Add authorship information (_Doxygen headers / comment blocks_) to all source files created/modified in the **rpitx-ui** fork.

## Changes

### Source files (`src/pissb/`, `src/utils/`)
Added Doxygen documentation block with the following tags to 12 `.cpp`/`.h` files:
```cpp
 * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
 * @date 27.03.2026
 * @copyright GPL-3.0
 * @see https://github.com/IgrikXD/rpitx-ui
 * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
```

### CMake files
Added plain comment authorship block to:
- `CMakeLists.txt`
- `src/CMakeLists.txt`

### Shell scripts
Added plain comment authorship block to:
- `scripts/testusb.sh`
- `scripts/testlsb.sh`