### PR TITLE
[GitHub Actions] Add monthly scheduled build trigger

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -1,6 +1,8 @@
 name: rpitx-ui build
 
 on:
+  schedule:
+    - cron: '0 0 1 * *'
   push:
     branches: [master]
     paths:


### PR DESCRIPTION
Add a `schedule` trigger to the CI workflow so that it runs automatically on the **1st of each month at 00:00 UTC**.

This ensures the build pipeline is exercised regularly, even without code changes, catching any environment or dependency regressions early.