### PR TITLE
[Refactoring] Remove obsolete entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,2 @@
-/piam
-/pidcf77
-/pifm
-/pifsq
-/pissb
-/pisstv
-/rpitx
-*.o
+.claude/
 build/


### PR DESCRIPTION
### Problem description

The `.gitignore` file contains entries (`/piam`, `/pidcf77`, `/pifm`, `/pifsq`, `/pissb`, `/pisstv`, `/rpitx`, `*.o`) that are leftover from the original [F5OEO/rpitx](https://github.com/F5OEO/rpitx) in-tree build layout. Since the project was migrated to CMake, all build artifacts are produced inside the `build/` directory, making these per-binary and `*.o` ignore rules dead entries that no longer match any actual output paths.

### Fix description

- **.gitignore**: Removed 8 obsolete entries (`/piam`, `/pidcf77`, `/pifm`, `/pifsq`, `/pissb`, `/pisstv`, `/rpitx`, `*.o`) that targeted the old in-tree build artifacts. Added `.claude/` to ignore the Claude Code local configuration directory. The remaining `build/` entry continues to cover all CMake output.