### PR TITLE
[CI/CD] Update actions/checkout from v4 to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build & verify on Raspberry Pi OS (arm64)
         uses: pguyot/arm-runner-action@v2


### PR DESCRIPTION
### Problem description

The CI workflow uses `actions/checkout@v4`, which runs on Node.js 20. GitHub is deprecating Node.js 20 for GitHub Actions runners — it will be forced to Node.js 24 starting June 2nd, 2026, and Node.js 20 will be removed entirely on September 16th, 2026. This produces a deprecation warning on every workflow run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

### Fix description

- **`.github/workflows/rpitx-ui-build.yml`**: Updated `actions/checkout` from `v4` to `v6`, which natively runs on Node.js 24 and eliminates the deprecation warning.