### PR TITLE
[CI/CD] Add clang-format check workflow for pull requests

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -9,7 +9,6 @@ on:
       - 'src/**/*.c'
       - 'src/**/*.h'
       - '.clang-format'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -1,0 +1,47 @@
+name: Code format
+
+on:
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - 'src/**/*.hpp'
+      - 'src/**/*.cpp'
+      - 'src/**/*.c'
+      - 'src/**/*.h'
+      - '.clang-format'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write # Needed for thread-comments
+  pull-requests: write # Needed for format-review
+
+jobs:
+  code-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run clang-format via cpp-linter
+        id: linter
+        uses: cpp-linter/cpp-linter-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: 'file' # Use .clang-format config file in the repo
+          tidy-checks: '-*' # Disable clang-tidy checks
+          version: '21'
+          files-changed-only: true
+          # Always delete an outdated thread comment and post a new comment
+          thread-comments: ${{ github.event_name == 'pull_request' && 'true' }}
+          # Enable PR reviews from clang-format
+          format-review: ${{ github.event_name == 'pull_request' && 'true' }}
+
+      - name: Check clang-format results
+        if: steps.linter.outputs.clang-format-checks-failed > 0
+        run: exit 1


### PR DESCRIPTION
### Problem description

There is no automated check that enforces the project's `.clang-format` style on contributed code. Formatting deviations are only caught during manual review, which burns reviewer time on mechanical nits and lets inconsistent style slip into the repository. The project carries a substantial amount of legacy code from the upstream repository that does not conform to the current `.clang-format`, so a naive "format the whole tree" check would flood every PR with unrelated violations.

### Fix description

- **.github/workflows/code-format.yml**: New workflow. Runs [`cpp-linter/cpp-linter-action@v2`](https://cpp-linter.github.io/cpp-linter-action/) on pull requests to verify formatting only on C/C++ files that the PR itself changes (`files-changed-only: true`), leaving legacy code untouched. Uses the repository's `.clang-format` via `style: 'file'`, pins `clang-format` to version `21` for reproducibility across runs, and disables `clang-tidy` checks (`tidy-checks: '-*'`) so the workflow focuses purely on formatting. The action posts a thread comment with a summary and an inline format review with per-line suggestions that can be applied with one click; both features are gated by `github.event_name == 'pull_request'` as a defensive guard in case additional triggers are added later. Triggers only on PRs that touch `src/**/*.{c,cpp,h,hpp}` or `.clang-format` itself. Grants `contents: write` (_required by `thread-comments`_) and `pull-requests: write` (_required by `format-review`_).