### PR TITLE
[CI/CD] Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "IgrikXD"
+    labels:
+      - "CI/CD"
+    commit-message:
+      prefix: "[CI/CD]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     labels:
       - "CI/CD"
     commit-message:
-      prefix: "[CI/CD]"
+      prefix: "Dependabot"


### PR DESCRIPTION
### Problem description

The project pins third-party GitHub Actions by major version (`actions/checkout@v6`, `pguyot/arm-runner-action@v2`, `cpp-linter/cpp-linter-action@v2`). When upstream publishes new major versions, security patches, or runtime migrations (_e.g. the Node.js 20 → 24 deprecation that triggered #30_), there is no mechanism that surfaces the update — it is noticed only when a deprecation warning appears in CI logs or a workflow breaks outright. Tracking action versions manually for a low-traffic repository is not sustainable.

### Fix description

- **.github/dependabot.yml**: New file. Enables Dependabot for the `github-actions` ecosystem with `directory: "/"` so that all workflow files under `.github/workflows/` are scanned. Runs on a `monthly` schedule, matching the existing monthly CI cron in `rpitx-ui-build.yml`. Each generated pull request is auto-assigned to `IgrikXD`, labeled `CI/CD` to match the project's labeling convention, and uses the `Dependabot` commit-message prefix so auto-generated PRs are visually distinct from manually authored `[CI/CD]` PRs (_Dependabot appends a colon after a prefix that ends with a letter, producing titles like `Dependabot: bump actions/checkout from 6 to 7`_). No `gitsubmodule` ecosystem is configured because the repository has no submodules.