### PR TITLE
[Release] Bump package version to 1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.25)
 project(rpitx-ui
-    VERSION 1.5
+    VERSION 1.6
     DESCRIPTION "RF transmitter for Raspberry Pi with improved UI functionality, built with CMake."
     LANGUAGES C CXX ASM
 )

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Your support helps me continue developing open-source projects like [WSPR-beacon](https://github.com/IgrikXD/WSPR-beacon) and [Easy-SDR](https://github.com/IgrikXD/Easy-SDR), while also enabling the creation of new tools that benefit the community.
 
 ## Current development progress
-[![GitHub Actions: rpitx-ui build status][rpitx-ui-build-badge]](https://github.com/IgrikXD/rpitx-ui/actions/workflows/rpitx-ui-build.yml)&nbsp;![Package version](https://img.shields.io/badge/latest%20package%20version-1.5-blue.svg?longCache=true&style=for-the-badge) 
+[![GitHub Actions: rpitx-ui build status][rpitx-ui-build-badge]](https://github.com/IgrikXD/rpitx-ui/actions/workflows/rpitx-ui-build.yml)&nbsp;![Package version](https://img.shields.io/badge/latest%20package%20version-1.6-blue.svg?longCache=true&style=for-the-badge) 
 
 ## Installation process
 Clone the **rpitx-ui** repository:

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
 
 # rpitx-ui package version
-PACKAGE_VERSION='1.5'
+PACKAGE_VERSION='1.6'
 
 # Terminal color helpers (ANSI escape sequences)
 COLOR_GREEN=$'\033[32m'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,7 @@
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
 
 # rpitx-ui package version
-PACKAGE_VERSION='1.5'
+PACKAGE_VERSION='1.6'
 
 # Terminal color helpers (ANSI escape sequences)
 COLOR_GREEN=$'\033[32m'


### PR DESCRIPTION
### Problem description

The **[rpitx-ui](https://github.com/IgrikXD/rpitx-ui)** package version is still reported as `1.5` across the build system, installation scripts, and README badge, while `master` already contains the full set of changes scheduled for the **rpitx-ui-stable-1.6** release (_pichirp modernization, CLI/signal-handling unification, chirp source rename, removal of unused Python bindings, parallel third-party dependency compilation, pimorse dit timing and ITU punctuation fix, and CI/CD additions — see the commits between `rpitx-ui-stable-1.5` and `master`_). Without bumping the version, the published `1.6` release tag would ship with all build artifacts, install banners, and README badge still advertising the previous `1.5` version.

### Fix description

#### CMake build changes
- **CMakeLists.txt** (_root_): Bumped `project(rpitx-ui VERSION ...)` from `1.5` to `1.6`.

#### Installation and uninstallation scripts
- **install.sh**: Bumped `PACKAGE_VERSION` from `1.5` to `1.6` so the install banners and `rpitx-ui-${PACKAGE_VERSION}` log messages reflect the new release.
- **uninstall.sh**: Bumped `PACKAGE_VERSION` from `1.5` to `1.6` to match `install.sh` and keep the uninstall banners consistent with the installed version.

#### Documentation
- **README.md**: Bumped the "latest package version" badge from `1.5` to `1.6`.