### PR TITLE
[Core] Introduce shared audio, CLI, and DSP utility libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # ----------------------------------------------------------
 # Compiler version check
 # ----------------------------------------------------------
-# Floating-point std::from_chars (used in src/utils/cli_utils.h) requires
-# libstdc++ >= 11, which ships with GCC 11+.
+# Floating-point std::from_chars (used in src/utils/cli/cli_common.cpp) requires
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
         message(FATAL_ERROR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Compiler version check
 # ----------------------------------------------------------
 # Floating-point std::from_chars (used in src/utils/cli/cli_common.cpp) requires
+# libstdc++ >= 11, which ships with GCC 11+.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
         message(FATAL_ERROR

--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,11 @@ sudo apt-get install -y \
   buffer \
   cmake \
   imagemagick \
+  libcli11-dev \
   libfftw3-dev \
   libsndfile1-dev \
+  libsoxr-dev \
+  pkg-config \
   rtl-sdr
 print_banner "$COLOR_YELLOW" 'System dependencies installed successfully!'
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,15 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 27.03.2026
+# Date: 28.04.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Project-specific shared utility libraries
+# ----------------------------------------------------------
+add_subdirectory(utils/dsp)
+add_subdirectory(utils/audio)
+add_subdirectory(utils/cli)
 
 # Required libraries (installed by install.sh)
 find_library(SNDFILE_LIBRARY sndfile REQUIRED)

--- a/src/utils/audio/CMakeLists.txt
+++ b/src/utils/audio/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 29.04.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Shared audio utility library
+# ----------------------------------------------------------
+# Provides the audio front-end shared by every transmitter binary:
+# a libsndfile-backed file source (AudioSource / LibsndfileAudioSource),
+# a libsoxr-backed streaming rate converter (SoxrResampler /
+# AudioRateConverter), and an AudioPipeline that wires source -> loop-aware
+# block reader -> channel adapter -> per-channel rate conversion to deliver
+# fixed-size interleaved float blocks at the caller's target sample rate.
+# ----------------------------------------------------------
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SNDFILE REQUIRED IMPORTED_TARGET sndfile)
+pkg_check_modules(SOXR REQUIRED IMPORTED_TARGET soxr)
+
+add_library(rpitx_audio_utils STATIC
+    audio_pipeline.cpp
+    audio_rate_converter.cpp
+    libsndfile_audio_source.cpp
+    soxr_resampler.cpp
+)
+target_include_directories(rpitx_audio_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(rpitx_audio_utils PRIVATE PkgConfig::SNDFILE PkgConfig::SOXR)

--- a/src/utils/audio/audio_pipeline.cpp
+++ b/src/utils/audio/audio_pipeline.cpp
@@ -1,0 +1,386 @@
+/**
+ * @file audio_pipeline.cpp
+ * @brief Shared audio pipeline helper implementations.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "audio_pipeline.h"
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+bool validateAudioFormat(AudioFormat format, int minSampleRate, int maxSampleRate) {
+    if (format.channels != 1 && format.channels != 2) {
+        std::cerr << "[ERROR] Input must be mono or stereo, got " << format.channels << " channels." << std::endl;
+        return false;
+    }
+
+    if (format.sampleRate < minSampleRate || format.sampleRate > maxSampleRate) {
+        std::cerr << "[ERROR] Input sample rate " << format.sampleRate << " Hz is outside the supported range ["
+                  << minSampleRate << ", " << maxSampleRate << "]." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool validateLoopSupport(const AudioSource& source, bool loopRequested) {
+    if (loopRequested && source.seekable() == false) {
+        std::cerr << "[ERROR] Audio source is not seekable; Loop is unsupported on this input." << std::endl;
+        return false;
+    }
+    return true;
+}
+
+AudioPipeline::AudioBlockReader::AudioBlockReader(AudioSource& source, int channels, bool loop)
+    : source_{source}, channels_{channels}, loop_{loop} {
+    if (channels <= 0) {
+        throw std::invalid_argument{"AudioBlockReader: channels must be positive, got " + std::to_string(channels)};
+    }
+    if (loop_) {
+        crossfadeBuffer_.assign(kCrossfadeFrames * static_cast<std::size_t>(channels_), 0.0F);
+    }
+}
+
+AudioPipelineStatus AudioPipeline::AudioBlockReader::read(std::span<float> dst) {
+    // Caller contract: dst must be a non-empty whole number of frames.
+    // Surface as throw (consistent with downmixInterleavedToMono and the
+    // ctors below) so a programmer error never silently degrades to a
+    // runtime status code.
+    if (dst.empty() || dst.size() % static_cast<std::size_t>(channels_) != 0) {
+        throw std::invalid_argument{"AudioBlockReader::read: dst must be a non-empty whole number of frames (size " +
+                                    std::to_string(dst.size()) + ", channels " + std::to_string(channels_) + ")"};
+    }
+
+    // Promote any deferred boundary from the previous call (see
+    // pendingLoopBoundary_ doc-string in audio_pipeline.h).
+    restartedThisRead_   = pendingLoopBoundary_;
+    pendingLoopBoundary_ = false;
+
+    std::size_t filledSamples{0};
+    bool rewoundSinceProgress{false};
+
+    while (filledSamples < dst.size()) {
+        const std::size_t samplesRead{source_.read(dst.subspan(filledSamples))};
+
+        if (samplesRead > 0) {
+            if (samplesRead % static_cast<std::size_t>(channels_) != 0) {
+                throw std::logic_error{"AudioBlockReader::read: source returned a partial frame (" +
+                                       std::to_string(samplesRead) + " samples, channels " + std::to_string(channels_) +
+                                       ")"};
+            }
+            filledSamples += samplesRead;
+            rewoundSinceProgress = false;
+            if (source_.error()) {
+                return AudioPipelineStatus::Error;
+            }
+            continue;
+        }
+
+        if (source_.error()) {
+            return AudioPipelineStatus::Error;
+        }
+
+        // EOF in non-loop mode is terminal.
+        if (loop_ == false) {
+            if (filledSamples == 0) {
+                return AudioPipelineStatus::End;
+            }
+            std::fill(dst.begin() + static_cast<std::ptrdiff_t>(filledSamples), dst.end(), 0.0F);
+            return AudioPipelineStatus::Ok;
+        }
+
+        // Loop mode: rewind in place to keep the loop boundary gap-free.
+        // A short crossfade smooths the seam when pre-rewind tail is
+        // present in the buffer; on a block-aligned EOF there is no tail
+        // and consumeLoopBoundary() lets the converter reset cleanly.
+        if (rewoundSinceProgress) {
+            // Source produced nothing after a rewind: it is empty.
+            if (filledSamples == 0) {
+                return AudioPipelineStatus::End;
+            }
+            // Tail of the block holds pre-rewind data plus a zero pad.
+            // Defer the boundary signal so the next read() resets the
+            // converter before processing post-rewind data: signalling
+            // it now would discard the pre-rewind tail still queued in
+            // the converter's filter state.
+            pendingLoopBoundary_ = true;
+            std::fill(dst.begin() + static_cast<std::ptrdiff_t>(filledSamples), dst.end(), 0.0F);
+            return AudioPipelineStatus::Ok;
+        }
+
+        const std::size_t chCount{static_cast<std::size_t>(channels_)};
+        const std::size_t blendFrames{std::min(kCrossfadeFrames, filledSamples / chCount)};
+
+        if (source_.rewind() == false) {
+            return AudioPipelineStatus::Error;
+        }
+        rewoundSinceProgress = true;
+
+        if (blendFrames < 2) {
+            // Block-aligned boundary, or pre-tail too short to blend.
+            if (filledSamples == 0) {
+                restartedThisRead_ = true;
+            }
+            continue;
+        }
+
+        // Pull blendFrames of post-rewind audio into scratch (handle short reads).
+        const std::size_t blendSamples{blendFrames * chCount};
+        std::size_t headFilled{0};
+        while (headFilled < blendSamples) {
+            const std::size_t got{
+                source_.read(std::span<float>{crossfadeBuffer_.data() + headFilled, blendSamples - headFilled})};
+            if (source_.error()) {
+                return AudioPipelineStatus::Error;
+            }
+            if (got == 0) {
+                break;
+            }
+            if (got % chCount != 0) {
+                throw std::logic_error{"AudioBlockReader::read: source returned a partial frame during crossfade (" +
+                                       std::to_string(got) + " samples, channels " + std::to_string(channels_) + ")"};
+            }
+            headFilled += got;
+        }
+
+        if (headFilled < blendSamples) {
+            // File shorter than the crossfade window: append what we got
+            // and let the outer loop hit EOF again.
+            std::copy(crossfadeBuffer_.begin(),
+                      crossfadeBuffer_.begin() + static_cast<std::ptrdiff_t>(headFilled),
+                      dst.begin() + static_cast<std::ptrdiff_t>(filledSamples));
+            filledSamples += headFilled;
+            if (headFilled > 0) {
+                rewoundSinceProgress = false;
+            }
+            continue;
+        }
+
+        // Linear crossfade in place over the trailing blendFrames of dst:
+        // w goes 0 -> 1 per frame, so the seam matches both surrounding
+        // sides without a discontinuity.
+        const std::size_t blendStart{filledSamples - blendSamples};
+        const float invDenom{1.0F / static_cast<float>(blendFrames - 1)};
+        std::size_t dstIdx{blendStart};
+        std::size_t srcIdx{0};
+        for (std::size_t f{0}; f < blendFrames; ++f) {
+            const float w{static_cast<float>(f) * invDenom};
+            const float invW{1.0F - w};
+            for (std::size_t c{0}; c < chCount; ++c) {
+                dst[dstIdx] = dst[dstIdx] * invW + crossfadeBuffer_[srcIdx] * w;
+                ++dstIdx;
+                ++srcIdx;
+            }
+        }
+        // Source is now at frame blendFrames of the rewound file; the
+        // outer loop fills the remainder. Reset the empty-source guard
+        // since post-head data was successfully consumed.
+        rewoundSinceProgress = false;
+    }
+
+    return AudioPipelineStatus::Ok;
+}
+
+namespace {
+    void downmixInterleavedToMono(std::span<const float> interleaved, int channels, std::span<float> mono) {
+        if (channels <= 0) {
+            throw std::invalid_argument{"downmixInterleavedToMono: channels must be positive, got " +
+                                        std::to_string(channels)};
+        }
+        const auto chCount{static_cast<std::size_t>(channels)};
+        if (interleaved.size() != mono.size() * chCount) {
+            throw std::invalid_argument{"downmixInterleavedToMono: interleaved size (" +
+                                        std::to_string(interleaved.size()) + ") must equal mono size (" +
+                                        std::to_string(mono.size()) + ") * channels (" + std::to_string(channels) +
+                                        ")"};
+        }
+        if (channels == 1) {
+            std::copy(interleaved.begin(), interleaved.end(), mono.begin());
+            return;
+        }
+
+        const float scale{1.0F / static_cast<float>(channels)};
+        for (std::size_t i{0}; i < mono.size(); ++i) {
+            float sum{0.0F};
+            for (std::size_t c{0}; c < chCount; ++c) {
+                sum += interleaved[i * chCount + c];
+            }
+            mono[i] = sum * scale;
+        }
+    }
+}  // namespace
+
+AudioPipeline::AudioPipeline(AudioSource& source, AudioPipelineConfig config)
+    : sourceFormat_{source.format()},
+      config_{std::move(config)},
+      outputChannels_{config_.channelMode == AudioChannelMode::Mono ? 1 : sourceFormat_.channels} {
+    if (sourceFormat_.channels <= 0) {
+        throw std::invalid_argument{"AudioPipeline: source channel count must be positive, got " +
+                                    std::to_string(sourceFormat_.channels)};
+    }
+    // outputChannels_ is derived from sourceFormat_.channels (or fixed at 1
+    // for the Mono mode) and is therefore positive whenever the source check
+    // above passes - no separate guard required.
+
+    rateConverters_.reserve(static_cast<std::size_t>(outputChannels_));
+    for (int c{0}; c < outputChannels_; ++c) {
+        rateConverters_.emplace_back(sourceFormat_.sampleRate, config_.targetSampleRate, config_.targetOutputFrames);
+    }
+
+    // Per-channel converters are configured identically and start their
+    // Bresenham accumulators from the same value, so any one of them is
+    // representative of the whole channel array.
+    maxInputFrames_ = rateConverters_.front().maxInputFrames();
+    outputFrames_   = rateConverters_.front().outputFrames();
+    reader_.emplace(source, sourceFormat_.channels, config_.loop);
+
+    // Buffers are sized for the worst-case input block. The actual per-call
+    // read uses the converter's peekNextInputFrames(), which never exceeds
+    // maxInputFrames_, and the surplus capacity is simply unused that call.
+    interleavedInput_.assign(maxInputFrames_ * static_cast<std::size_t>(sourceFormat_.channels), 0.0F);
+    channelInput_.assign(static_cast<std::size_t>(outputChannels_), std::vector<float>(maxInputFrames_, 0.0F));
+    channelOutput_.assign(static_cast<std::size_t>(outputChannels_), std::vector<float>(outputFrames_, 0.0F));
+}
+
+AudioPipelineStatus AudioPipeline::read(std::span<float> out) {
+    // Caller contract: output buffer must match the block size declared at
+    // construction, and the pipeline must have been fully initialised.
+    if (reader_ == std::nullopt) {
+        throw std::logic_error{"AudioPipeline::read: pipeline is not initialised"};
+    }
+    if (out.size() != outputSamplesPerBlock()) {
+        throw std::invalid_argument{"AudioPipeline::read: out.size() (" + std::to_string(out.size()) +
+                                    ") must equal outputSamplesPerBlock() (" + std::to_string(outputSamplesPerBlock()) +
+                                    ")"};
+    }
+    if (drained_) {
+        return AudioPipelineStatus::End;
+    }
+    if (draining_) {
+        return drainBlock(out);
+    }
+
+    // All converters share the same rate parameters and Bresenham state so
+    // they require the same input frame count on every call; query just one.
+    const std::size_t inputFramesThisCall{rateConverters_.front().peekNextInputFrames()};
+    const std::size_t interleavedSize{inputFramesThisCall * static_cast<std::size_t>(sourceFormat_.channels)};
+    // Internal invariant: AudioRateConverter must never request more than
+    // maxInputFrames_ per call, which is exactly what interleavedInput_ is
+    // sized for. A future contract drift would be a logic bug, not a
+    // runtime IO failure - surface it as such.
+    if (interleavedSize > interleavedInput_.size()) {
+        throw std::logic_error{"AudioPipeline::read: rate converter requested " + std::to_string(interleavedSize) +
+                               " interleaved samples, exceeding buffer capacity " +
+                               std::to_string(interleavedInput_.size())};
+    }
+
+    const auto status{reader_->read({interleavedInput_.data(), interleavedSize})};
+    if (status == AudioPipelineStatus::Error) {
+        return AudioPipelineStatus::Error;
+    }
+    if (status == AudioPipelineStatus::End) {
+        // Source ran out before yielding any new samples. Switch to drain
+        // mode so the converter tails surface in subsequent calls instead
+        // of being discarded together with the input stream.
+        draining_ = true;
+        return drainBlock(out);
+    }
+
+    // The reader may have just performed a deferred rewind to start a fresh
+    // loop iteration. Reset filter state on every converter (preserving the
+    // Bresenham accumulator) so the previous iteration's filter tail does
+    // not smear into the start of this block.
+    if (reader_->consumeLoopBoundary()) {
+        for (auto& converter: rateConverters_) {
+            converter.reset();
+        }
+    }
+
+    if (config_.channelMode == AudioChannelMode::Mono) {
+        downmixInterleavedToMono(std::span<const float>{interleavedInput_.data(), interleavedSize},
+                                 sourceFormat_.channels,
+                                 std::span<float>{channelInput_[0].data(), inputFramesThisCall});
+    } else {
+        for (int c{0}; c < outputChannels_; ++c) {
+            auto& channel{channelInput_[static_cast<std::size_t>(c)]};
+            for (std::size_t i{0}; i < inputFramesThisCall; ++i) {
+                channel[i] = interleavedInput_[i * static_cast<std::size_t>(sourceFormat_.channels) +
+                                               static_cast<std::size_t>(c)];
+            }
+        }
+    }
+
+    for (int c{0}; c < outputChannels_; ++c) {
+        const bool converted{rateConverters_[static_cast<std::size_t>(c)].process(
+            std::span<const float>{channelInput_[static_cast<std::size_t>(c)].data(), inputFramesThisCall},
+            std::span<float>{channelOutput_[static_cast<std::size_t>(c)].data(), outputFrames_})};
+        if (converted == false) {
+            return AudioPipelineStatus::Error;
+        }
+    }
+
+    if (outputChannels_ == 1) {
+        std::copy(channelOutput_[0].begin(), channelOutput_[0].end(), out.begin());
+    } else {
+        for (std::size_t i{0}; i < outputFrames_; ++i) {
+            for (int c{0}; c < outputChannels_; ++c) {
+                out[i * static_cast<std::size_t>(outputChannels_) + static_cast<std::size_t>(c)] =
+                    channelOutput_[static_cast<std::size_t>(c)][i];
+            }
+        }
+    }
+
+    return AudioPipelineStatus::Ok;
+}
+
+AudioPipelineStatus AudioPipeline::drainBlock(std::span<float> out) {
+    // Pull each converter's tail (spilled samples plus libsoxr filter
+    // residue) into its channel buffer and zero-pad the unused slots so
+    // the interleave step below treats every channel uniformly. All
+    // converters share the same filter geometry and processed history, so
+    // they always drain the same per-block sample count - tracking just
+    // one channel's count is sufficient to decide when we are fully done.
+    std::size_t producedAnyChannel{0};
+    for (int c{0}; c < outputChannels_; ++c) {
+        auto& channel{channelOutput_[static_cast<std::size_t>(c)]};
+        const auto produced{
+            rateConverters_[static_cast<std::size_t>(c)].drain(std::span<float>{channel.data(), outputFrames_})};
+        if (produced == std::nullopt) {
+            return AudioPipelineStatus::Error;
+        }
+        const std::size_t produced_n{produced.value()};
+        if (produced_n > producedAnyChannel) {
+            producedAnyChannel = produced_n;
+        }
+        if (produced_n < outputFrames_) {
+            std::fill(channel.begin() + static_cast<std::ptrdiff_t>(produced_n), channel.end(), 0.0F);
+        }
+    }
+
+    if (producedAnyChannel == 0) {
+        drained_ = true;
+        return AudioPipelineStatus::End;
+    }
+
+    if (outputChannels_ == 1) {
+        std::copy(channelOutput_[0].begin(), channelOutput_[0].end(), out.begin());
+    } else {
+        for (std::size_t i{0}; i < outputFrames_; ++i) {
+            for (int c{0}; c < outputChannels_; ++c) {
+                out[i * static_cast<std::size_t>(outputChannels_) + static_cast<std::size_t>(c)] =
+                    channelOutput_[static_cast<std::size_t>(c)][i];
+            }
+        }
+    }
+
+    return AudioPipelineStatus::Ok;
+}

--- a/src/utils/audio/audio_pipeline.h
+++ b/src/utils/audio/audio_pipeline.h
@@ -1,0 +1,225 @@
+/**
+ * @file audio_pipeline.h
+ * @brief Shared audio block reading, channel adaptation, and mono rate-conversion pipeline.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "audio_rate_converter.h"
+#include "audio_source.h"
+
+/**
+ * @brief Result of pulling one audio block through a shared pipeline stage.
+ */
+enum class AudioPipelineStatus {
+    Ok,     ///< A full output block is available.
+    End,    ///< Clean end-of-stream before any new samples were read.
+    Error,  ///< I/O, rewind, or format-contract failure.
+};
+
+/**
+ * @brief Validate that an AudioSource format is mono / stereo and in a sample-rate range.
+ *
+ * Prints a concise diagnostic to stderr on failure.
+ *
+ * @param format        Source format to validate.
+ * @param minSampleRate Inclusive minimum sample rate in Hz.
+ * @param maxSampleRate Inclusive maximum sample rate in Hz.
+ * @return true when the format is usable by the caller.
+ */
+[[nodiscard]] bool validateAudioFormat(AudioFormat format, int minSampleRate, int maxSampleRate);
+
+/**
+ * @brief Validate that a source can satisfy requested loop playback.
+ *
+ * Prints a concise diagnostic to stderr on failure.
+ *
+ * @param source        Source to inspect.
+ * @param loopRequested Whether the caller requested loop playback.
+ * @return true when playback can proceed.
+ */
+[[nodiscard]] bool validateLoopSupport(const AudioSource& source, bool loopRequested);
+
+/**
+ * @brief Channel-adaptation mode for AudioPipeline.
+ */
+enum class AudioChannelMode {
+    Preserve,  ///< Keep source channels and resample each independently.
+    Mono,      ///< Downmix all source channels to one mono channel.
+};
+
+/**
+ * @brief Configuration for AudioPipeline.
+ */
+struct AudioPipelineConfig {
+    bool loop;
+    int targetSampleRate;
+    std::size_t targetOutputFrames;
+    AudioChannelMode channelMode;
+};
+
+/**
+ * @brief AudioSource -> loop-aware block reader -> channel adapter -> rate converter.
+ *
+ * Produces fixed-size interleaved float blocks at the caller's target sample
+ * rate. Mono-only transmitters request AudioChannelMode::Mono; stereo-aware
+ * processors such as pifmrds request AudioChannelMode::Preserve.
+ */
+class AudioPipeline {
+public:
+    /**
+     * @brief Construct the pipeline from an already-open source.
+     *
+     * @param source Source to read from; must outlive this pipeline.
+     * @param config Pipeline policy and target block geometry.
+     *
+     * @throws std::invalid_argument when the source channel count is non-positive,
+     *         when an internal AudioRateConverter rejects the rate parameters
+     *         (non-positive rates, non-positive output frames), or when the
+     *         derived per-call input frame count overflows std::size_t.
+     * @throws std::runtime_error    when an internal AudioRateConverter cannot
+     *         create its libsoxr backend.
+     */
+    AudioPipeline(AudioSource& source, AudioPipelineConfig config);
+
+    AudioPipeline(const AudioPipeline&)            = delete;
+    AudioPipeline& operator=(const AudioPipeline&) = delete;
+    AudioPipeline(AudioPipeline&&)                 = delete;
+    AudioPipeline& operator=(AudioPipeline&&)      = delete;
+
+    [[nodiscard]] int outputChannels() const noexcept {
+        return outputChannels_;
+    }
+    [[nodiscard]] std::size_t outputFrames() const noexcept {
+        return outputFrames_;
+    }
+    [[nodiscard]] std::size_t outputSamplesPerBlock() const noexcept {
+        return outputFrames_ * static_cast<std::size_t>(outputChannels_);
+    }
+
+    /**
+     * @brief Read and convert one block at the target sample rate.
+     *
+     * @param out Destination block, interleaved by outputChannels().
+     * @return Ok on a normal block, End once the source and converter
+     *         tails are exhausted, or Error on an underlying source / rate
+     *         converter runtime failure.
+     *
+     * @throws std::invalid_argument if out.size() does not equal
+     *         outputSamplesPerBlock() (caller contract violation).
+     * @throws std::logic_error on an internal invariant violation
+     *         (e.g. converter requesting more input than the buffer can
+     *         hold, source returning a partial frame).
+     */
+    [[nodiscard]] AudioPipelineStatus read(std::span<float> out);
+
+private:
+    class AudioBlockReader {
+    public:
+        AudioBlockReader(AudioSource& source, int channels, bool loop);
+
+        AudioBlockReader(const AudioBlockReader&)            = delete;
+        AudioBlockReader& operator=(const AudioBlockReader&) = delete;
+        AudioBlockReader(AudioBlockReader&&)                 = delete;
+        AudioBlockReader& operator=(AudioBlockReader&&)      = delete;
+
+        /**
+         * @brief Read exactly dst.size() samples from the source.
+         *
+         * Block size is chosen per-call by the caller; this reader is
+         * rate-agnostic and only enforces channel alignment.
+         *
+         * In loop mode reads are gap-free: on EOF the source is rewound
+         * in place and the same block keeps filling. A short linear
+         * crossfade (kCrossfadeFrames) smooths mid-block seams; on a
+         * block-aligned EOF consumeLoopBoundary() reports true so the
+         * converter filter state can be reset cleanly.
+         *
+         * @param dst Destination buffer; size must be a positive multiple
+         *            of the channel count established at construction.
+         *
+         * @throws std::invalid_argument if dst is empty or its size is not
+         *         a multiple of the channel count.
+         * @throws std::logic_error if the source returns a partial frame.
+         */
+        [[nodiscard]] AudioPipelineStatus read(std::span<float> dst);
+
+        /**
+         * @brief Whether the most recent read() began at a clean loop boundary.
+         *
+         * Returns true exactly once when the block whose conversion is
+         * about to start contains no pre-rewind tail - either because the
+         * read() filled it from scratch after a block-aligned EOF, or
+         * because a previous read() rewound the source after emitting its
+         * trailing tail and the current read() is the first one to carry
+         * post-rewind data. The caller should reset rate-converter filter
+         * state for such a block.
+         */
+        [[nodiscard]] bool consumeLoopBoundary() noexcept {
+            const bool result{restartedThisRead_};
+            restartedThisRead_ = false;
+            return result;
+        }
+
+    private:
+        /// Crossfade window in frames used to smooth mid-block loop seams.
+        /// 32 frames maps to ~0.17 ms @ 192 kHz and ~4 ms @ 8 kHz: long
+        /// enough to mask the filter discontinuity, short enough to be
+        /// inaudible against the surrounding signal.
+        static constexpr std::size_t kCrossfadeFrames{32};
+
+        AudioSource& source_;
+        int channels_;
+        bool loop_;
+        bool restartedThisRead_{
+            false};  ///< Set when the current block began at a loop boundary (visible to consumeLoopBoundary()).
+        /// Carries an unsignalled rewind from one read() into the next.
+        ///
+        /// Set when read() had to exit with pre-rewind tail in the block
+        /// (Ok + zero pad) before any post-rewind samples were available.
+        /// The next read() promotes it into restartedThisRead_ on entry,
+        /// so the converter reset surfaces on the call that first
+        /// processes post-rewind data, not on the same call that set it.
+        /// Promoting on entry (rather than OR-ing into
+        /// consumeLoopBoundary()) is what makes the deferral observable
+        /// on the *next* AudioPipeline::read() iteration instead of the
+        /// same one that triggered the rewind.
+        bool pendingLoopBoundary_{false};
+        std::vector<float> crossfadeBuffer_;  ///< Scratch for post-rewind head samples (loop mode only).
+    };
+
+    /**
+     * @brief Drive a draining block: pull each converter's tail into out.
+     *
+     * Called after the block reader has reported End in non-loop mode so
+     * libsoxr's filter delay line is recovered instead of being discarded
+     * with the source. Returns Ok with a partial-then-padded block while
+     * any converter still has tail samples, End once all converters are
+     * fully drained.
+     */
+    [[nodiscard]] AudioPipelineStatus drainBlock(std::span<float> out);
+
+    AudioFormat sourceFormat_;
+    AudioPipelineConfig config_;
+    int outputChannels_;
+    std::size_t maxInputFrames_{0};
+    std::size_t outputFrames_{0};
+    std::optional<AudioBlockReader> reader_;
+    std::vector<AudioRateConverter> rateConverters_;
+    std::vector<float> interleavedInput_;
+    std::vector<std::vector<float>> channelInput_;
+    std::vector<std::vector<float>> channelOutput_;
+    bool draining_{false};  ///< Switched on after the source reports End in non-loop mode.
+    bool drained_{false};   ///< Set once drainBlock() has returned all tail samples.
+};

--- a/src/utils/audio/audio_rate_converter.cpp
+++ b/src/utils/audio/audio_rate_converter.cpp
@@ -1,0 +1,208 @@
+/**
+ * @file audio_rate_converter.cpp
+ * @brief AudioRateConverter implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 29.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "audio_rate_converter.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+    /**
+     * @brief Headroom appended to the soxr staging buffer.
+     *
+     * Per-call output is bounded by ceil(maxInputFrames * tgt / src), but
+     * libsoxr's filter delay line can briefly emit a handful more samples
+     * during steady-state catch-up after warmup. The 64-sample pad is well
+     * above any plausible jitter and stays small enough to be inconsequential
+     * versus the per-converter heap footprint.
+     */
+    constexpr std::size_t STAGING_HEADROOM_SAMPLES{64};
+
+    [[nodiscard]] constexpr long long ceilDiv(long long num, long long den) noexcept {
+        return (num + den - 1) / den;
+    }
+
+    [[nodiscard]] std::size_t alignedMaxInputFrames(std::size_t targetOutputFrames, int sourceRateHz,
+                                                    int targetRateHz) {
+        const long long ceiled{ceilDiv(static_cast<long long>(targetOutputFrames) * sourceRateHz, targetRateHz)};
+        // ceiled is bounded below by 1 (positive inputs) and above by the
+        // chosen size_t domain - on 32-bit platforms size_t is narrower than
+        // long long, so the upper guard is not vacuous.
+        if (ceiled < 1LL || static_cast<unsigned long long>(ceiled) > std::numeric_limits<std::size_t>::max()) {
+            throw std::invalid_argument{"AudioRateConverter input frame count overflows std::size_t"};
+        }
+        return static_cast<std::size_t>(ceiled);
+    }
+}  // namespace
+
+AudioRateConverter::AudioRateConverter(int sourceRateHz, int targetRateHz, std::size_t targetOutputFrames)
+    : outputFrames_{0}, sourceRate_{0}, targetRate_{0}, maxInputFrames_{0}, inputAccumulator_{0}, spillReadPos_{0} {
+    if (sourceRateHz < 1 || targetRateHz < 1 || targetOutputFrames == 0) {
+        throw std::invalid_argument{"Invalid AudioRateConverter parameters"};
+    }
+
+    outputFrames_ = targetOutputFrames;
+    sourceRate_   = sourceRateHz;
+    targetRate_   = targetRateHz;
+
+    if (sourceRateHz == targetRateHz) {
+        // Passthrough: identical rates, every call accepts and emits the
+        // same fixed block. resampler_ stays nullopt; process() will memcpy.
+        maxInputFrames_ = targetOutputFrames;
+        return;
+    }
+
+    maxInputFrames_ = alignedMaxInputFrames(targetOutputFrames, sourceRateHz, targetRateHz);
+
+    // Staging buffer: max output soxr could produce from maxInputFrames_ inputs.
+    // ceil(maxInputFrames * tgt / src) is the rate-ratio bound; STAGING_HEADROOM
+    // covers libsoxr's per-call jitter so the call is guaranteed to consume
+    // every input frame (idone == ilen) instead of stalling at the output cap.
+    const long long maxStagingLL{ceilDiv(static_cast<long long>(maxInputFrames_) * targetRateHz, sourceRateHz)};
+    if (maxStagingLL < 1LL || static_cast<unsigned long long>(maxStagingLL) > std::numeric_limits<std::size_t>::max()) {
+        throw std::invalid_argument{"AudioRateConverter staging size overflows std::size_t"};
+    }
+    stagingBuffer_.assign(static_cast<std::size_t>(maxStagingLL) + STAGING_HEADROOM_SAMPLES, 0.0F);
+
+    // The spill rarely holds more than a few samples in steady state, but
+    // a pre-reserve avoids reallocations on the rare jitter events.
+    spill_.reserve(STAGING_HEADROOM_SAMPLES);
+
+    resampler_.emplace(sourceRateHz, targetRateHz);
+}
+
+std::optional<std::size_t> AudioRateConverter::drain(std::span<float> out) {
+    if (out.empty() || resampler_ == std::nullopt) {
+        // Passthrough mode has no internal state to drain - the source
+        // exhausting was already reported to the caller as End.
+        return std::size_t{0};
+    }
+
+    // 1. Emit any buffered spill samples first - these are real output the
+    // resampler already produced on prior calls but did not yet fit in the
+    // caller's block.
+    std::size_t outIdx{0};
+    {
+        const std::size_t available{spill_.size() - spillReadPos_};
+        const std::size_t take{std::min(available, out.size())};
+        std::copy_n(spill_.begin() + spillReadPos_, take, out.begin());
+        spillReadPos_ += take;
+        outIdx += take;
+        if (spillReadPos_ >= spill_.size()) {
+            spill_.clear();
+            spillReadPos_ = 0;
+        }
+    }
+
+    if (outIdx >= out.size()) {
+        return outIdx;
+    }
+
+    // 2. Pull soxr's filter tail with the documented end-of-stream flush
+    // form (empty input span). After this call libsoxr is in its post-flush
+    // state; reset() must be invoked before resuming normal process() use.
+    const auto result{resampler_.value().process(std::span<const float>{}, out.subspan(outIdx))};
+    if (result == std::nullopt) {
+        // Surface the libsoxr failure as nullopt so the pipeline reports
+        // Error, not End - silently treating a flush failure as a clean
+        // drain would mask a real fault and lose any spill we already
+        // emitted into out.
+        return std::nullopt;
+    }
+    outIdx += result.value().outputProduced;
+    return outIdx;
+}
+
+bool AudioRateConverter::process(std::span<const float> in, std::span<float> out) {
+    const std::size_t expectedIn{peekNextInputFrames()};
+    // expectedIn must be strictly positive: a zero-sized input span would
+    // dispatch to libsoxr's documented end-of-stream flush form, desynchronising
+    // the resampler for any subsequent calls. The audio_pipeline rate range
+    // (>= 8000 Hz input, output frames >= 1024) makes this unreachable, but
+    // the explicit guard documents the invariant.
+    if (expectedIn == 0 || in.size() != expectedIn || out.size() != outputFrames_) {
+        return false;
+    }
+
+    if (resampler_ == std::nullopt) {
+        // Passthrough: no Bresenham state, no soxr state - input and output
+        // spans have identical size by ctor invariant; std::copy is the
+        // canonical zero-overhead memcpy here.
+        std::copy(in.begin(), in.end(), out.begin());
+        return true;
+    }
+
+    // Compute the next Bresenham accumulator locally; commit only after the
+    // soxr call below succeeds so a mid-process failure leaves the converter
+    // in its prior state and a retry would request the same expectedIn.
+    // Net effect once committed: accumulator stays in [0, targetRate_), and
+    // over K calls the cumulative input matches K * outputFrames *
+    // sourceRate / targetRate exactly.
+    const long long nextAccumulator{inputAccumulator_ + static_cast<long long>(outputFrames_) * sourceRate_ -
+                                    static_cast<long long>(expectedIn) * static_cast<long long>(targetRate_)};
+
+    // 1. Drain any spill from previous call into the head of out.
+    std::size_t outIdx{0};
+    {
+        const std::size_t available{spill_.size() - spillReadPos_};
+        const std::size_t take{std::min(available, out.size())};
+        std::copy_n(spill_.begin() + spillReadPos_, take, out.begin());
+        spillReadPos_ += take;
+        outIdx += take;
+        if (spillReadPos_ >= spill_.size()) {
+            spill_.clear();
+            spillReadPos_ = 0;
+        }
+    }
+
+    // 2. Run soxr into the staging buffer. The staging buffer is sized so
+    // soxr stops on input exhaustion rather than the output cap; verify
+    // that invariant at runtime as a cheap guard against any future libsoxr
+    // version where the bound is no longer tight - silently dropping input
+    // samples here would degrade the output to carrier-only RF.
+    const auto result{resampler_.value().process(in, std::span<float>{stagingBuffer_})};
+    if (result == std::nullopt) {
+        return false;
+    }
+    if (result.value().inputConsumed != in.size()) {
+        return false;
+    }
+    // soxr accepted the full input span; safe to commit the accumulator now.
+    inputAccumulator_ = nextAccumulator;
+    const std::size_t produced{result.value().outputProduced};
+
+    // 3. Copy as many staging samples as fit into the remaining out slots;
+    // overflow goes into the spill for the next call.
+    const std::size_t toOut{std::min(produced, out.size() - outIdx)};
+    std::copy_n(stagingBuffer_.begin(), toOut, out.begin() + outIdx);
+    outIdx += toOut;
+
+    if (produced > toOut) {
+        // Compact any leftover spill head before appending so spill_.size()
+        // stays bounded by per-call jitter rather than growing across calls.
+        if (spillReadPos_ > 0) {
+            spill_.erase(spill_.begin(), spill_.begin() + spillReadPos_);
+            spillReadPos_ = 0;
+        }
+        spill_.insert(spill_.end(), stagingBuffer_.begin() + toOut, stagingBuffer_.begin() + produced);
+    }
+
+    // 4. Filter warmup: on the very first calls soxr has not yet seen
+    // enough input to compute every requested output position - the tail of
+    // out is padded with silence (typically a few hundred samples on the
+    // first call, zero from the second onward). Steady state with Bresenham
+    // input sizing always fills out in full.
+    if (outIdx < out.size()) {
+        std::fill(out.begin() + outIdx, out.end(), 0.0F);
+    }
+    return true;
+}

--- a/src/utils/audio/audio_rate_converter.h
+++ b/src/utils/audio/audio_rate_converter.h
@@ -1,0 +1,183 @@
+/**
+ * @file audio_rate_converter.h
+ * @brief Streaming sample-rate converter built on the SoxrResampler wrapper.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 29.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "soxr_resampler.h"
+
+/**
+ * @brief Single-channel streaming rate converter with a fixed output block contract.
+ *
+ * Wraps SoxrResampler so callers see a uniform fixed-size output block
+ * regardless of the source / target rate ratio. The input block size varies
+ * between calls via a Bresenham accumulator that tracks the rate ratio
+ * exactly - the backend halts on either input exhaustion or output cap, so a
+ * constant ceil()-rounded input with a tight output buffer
+ * would drop samples or grow an internal spill unbounded. With Bresenham
+ * sizing and an oversized staging buffer, libsoxr always consumes the full
+ * input span and the per-call output jitter (one or two samples) is absorbed
+ * by an internal spill.
+ *
+ * When sourceRateHz == targetRateHz no soxr instance is created and process()
+ * degrades to a memory copy.
+ *
+ * Non-copyable; movable so the converter can be deferred-constructed inside
+ * std::optional members (e.g. processors that learn the source rate at run
+ * time).
+ */
+class AudioRateConverter {
+public:
+    /**
+     * @brief Construct an AudioRateConverter for the given rate pair.
+     *
+     * @param sourceRateHz       Input sample rate in Hz (> 0).
+     * @param targetRateHz       Output sample rate in Hz (> 0).
+     * @param targetOutputFrames Output frames produced per process() call (> 0).
+     *                           Sets the latency budget at the output rate;
+     *                           in seconds this is targetOutputFrames /
+     *                           targetRateHz.
+     *
+     * @throws std::invalid_argument when any parameter is non-positive or when
+     *         the derived per-call input frame count overflows std::size_t.
+     * @throws std::runtime_error    when the underlying soxr handle cannot be created.
+     */
+    AudioRateConverter(int sourceRateHz, int targetRateHz, std::size_t targetOutputFrames);
+
+    AudioRateConverter(const AudioRateConverter&)            = delete;
+    AudioRateConverter& operator=(const AudioRateConverter&) = delete;
+    AudioRateConverter(AudioRateConverter&&)                 = default;
+    AudioRateConverter& operator=(AudioRateConverter&&)      = default;
+
+    /**
+     * @brief Output frames produced per process() call (constant).
+     */
+    [[nodiscard]] std::size_t outputFrames() const noexcept {
+        return outputFrames_;
+    }
+
+    /**
+     * @brief Maximum input frames any single process() call may demand.
+     *
+     * Used by the pipeline to size source-read buffers conservatively.
+     * Bresenham accumulator alternates between this value and one less.
+     */
+    [[nodiscard]] std::size_t maxInputFrames() const noexcept {
+        return maxInputFrames_;
+    }
+
+    /**
+     * @brief Input frames the next process() call expects.
+     *
+     * Pure: does not advance the Bresenham accumulator. Caller must read
+     * exactly this many input frames from the source and pass them to the
+     * matching process() call. After process(), the accumulator advances
+     * and a fresh peek may return a different value.
+     *
+     * The value is by construction in [0, maxInputFrames()].
+     */
+    [[nodiscard]] std::size_t peekNextInputFrames() const noexcept {
+        if (resampler_ == std::nullopt) {
+            return outputFrames_;
+        }
+        // Bresenham invariant: inputAccumulator_ stays in [0, targetRate_)
+        // and the cumulative input across K calls equals
+        // K * outputFrames * sourceRate / targetRate, rounded to the
+        // nearest integer at each step.
+        const long long total{inputAccumulator_ + static_cast<long long>(outputFrames_) * sourceRate_};
+        return static_cast<std::size_t>(total / targetRate_);
+    }
+
+    /**
+     * @brief Process one block of audio.
+     *
+     * @param in  Input frames; size must equal peekNextInputFrames().
+     * @param out Output frames; size must equal outputFrames().
+     * @return true on success, false when the buffer geometry is invalid
+     *         or soxr reports a processing error.
+     */
+    [[nodiscard]] bool process(std::span<const float> in, std::span<float> out);
+
+    /**
+     * @brief Reset filter state for a loop boundary.
+     *
+     * Empties the soxr filter delay line and drops any spilled output samples
+     * so the end-of-file filter tail does not smear into the start of the
+     * next iteration. The Bresenham accumulator is deliberately preserved
+     * across the boundary: the loop wraps the source content but the
+     * cumulative input/output rate ratio must keep tracking the target so
+     * peekNextInputFrames() of the call that triggered this reset still
+     * matches the input span the caller has already fetched, and longer
+     * looped playbacks do not accumulate sample-count drift.
+     */
+    void reset() {
+        spill_.clear();
+        spillReadPos_ = 0;
+        if (resampler_ != std::nullopt) {
+            resampler_.value().clear();
+        }
+        // inputAccumulator_ deliberately preserved across the boundary.
+    }
+
+    /**
+     * @brief Pull the converter's tail into out at end-of-stream.
+     *
+     * Drains spilled output samples first, then feeds soxr the documented
+     * end-of-stream flush form (empty input span) to recover any samples
+     * still buffered in the filter delay line.
+     *
+     * Once drain() has been called, the soxr instance is in libsoxr's
+     * post-flush state - call reset() before resuming normal process() use.
+     *
+     * @param out Output buffer; size must not exceed outputFrames().
+     * @return Number of frames written (0 .. out.size()) on success; 0 means
+     *         the converter is fully drained. std::nullopt when libsoxr
+     *         reports an error during the flush call - the caller should
+     *         treat this as a hard pipeline failure rather than a clean end.
+     */
+    [[nodiscard]] std::optional<std::size_t> drain(std::span<float> out);
+
+private:
+    std::size_t outputFrames_;
+    int sourceRate_;
+    int targetRate_;
+    std::size_t maxInputFrames_;
+    long long inputAccumulator_;  ///< Bresenham state in [0, targetRate).
+
+    std::optional<SoxrResampler> resampler_;  ///< nullopt = passthrough.
+
+    /**
+     * @brief Staging buffer for soxr's output writes.
+     *
+     * Sized to absorb the maximum number of output samples soxr can produce
+     * from maxInputFrames_ inputs (plus a small safety margin). Letting
+     * soxr fill a generous buffer guarantees idone == ilen on every call,
+     * so no input is silently dropped at the boundary where output would
+     * otherwise have filled first.
+     */
+    std::vector<float> stagingBuffer_;
+
+    /**
+     * @brief Pending output samples not yet returned to the caller.
+     *
+     * soxr's per-call output count jitters by one or two samples around
+     * the rate ratio even with Bresenham input sizing; the surplus is
+     * stashed here and drained at the head of the next process() call.
+     * Stored as a flat vector with a separate read offset so we can
+     * pop from the front in O(1) without a deque's per-element allocation.
+     */
+    std::vector<float> spill_;
+    std::size_t spillReadPos_;
+};

--- a/src/utils/audio/audio_source.h
+++ b/src/utils/audio/audio_source.h
@@ -1,0 +1,134 @@
+/**
+ * @file audio_source.h
+ * @brief Abstract streaming audio source interface for rpitx-ui transmitters.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <string_view>
+
+/**
+ * @brief Audio metadata exposed to consumers of an AudioSource.
+ *
+ * Only the two fields callers act on are surfaced: channels drives buffer
+ * sizing and mono / stereo branching, sampleRate drives resampler
+ * configuration. Bit depth and subtype (PCM_16, PCM_24, FLOAT, ...) are
+ * diagnostic-only and appear in AudioSource::description() - read() always
+ * yields normalized float in [-1.0, 1.0] regardless of on-disk encoding.
+ */
+struct AudioFormat {
+    int channels;    ///< Channel count (1 = mono, 2 = stereo, ...).
+    int sampleRate;  ///< Audio sample rate in Hz.
+};
+
+/**
+ * @brief Streaming pull-mode audio source producing normalized float samples.
+ *
+ * Concrete implementations wrap a backing decoder (libsndfile for files).
+ * Output is always interleaved float in [-1.0, 1.0] regardless of on-disk
+ * format so consumers do not have to branch on int16 / int24 / float / etc.
+ *
+ * Loop semantics live in the consumer, not in the source: when read() returns
+ * 0 the caller distinguishes EOF from a fatal error via error() and decides
+ * whether to call rewind() or stop. Sources stay policy-free; rewind() returns
+ * false on non-seekable backings, which the caller can pre-check via
+ * seekable() to fail fast on --loop over stdin / FIFO inputs.
+ */
+class AudioSource {
+public:
+    AudioSource(const AudioSource&)            = delete;
+    AudioSource& operator=(const AudioSource&) = delete;
+    AudioSource(AudioSource&&)                 = delete;
+    AudioSource& operator=(AudioSource&&)      = delete;
+
+    virtual ~AudioSource() = default;
+
+    /**
+     * @brief Audio metadata, available immediately after construction.
+     *
+     * @return Channel count and sample rate of the underlying stream.
+     */
+    [[nodiscard]] virtual AudioFormat format() const = 0;
+
+    /**
+     * @brief Human-readable description of the source for startup logging.
+     *
+     * Format and content are implementation-defined; intended only for
+     * single-line diagnostic banners (e.g. "WAV / Signed 24 bit PCM").
+     * Consumers must not parse this string - it has no stable schema.
+     *
+     * The returned view stays valid for the lifetime of the AudioSource.
+     *
+     * @return One-line description suitable for console output.
+     */
+    [[nodiscard]] virtual std::string_view description() const = 0;
+
+    /**
+     * @brief Read up to dst.size() interleaved float samples into dst.
+     *
+     * For stereo, samples are interleaved L, R, L, R, ... and dst.size()
+     * must be a non-empty whole multiple of format().channels. The caller
+     * derives frame count via dst.size() / format().channels.
+     *
+     * Returns the number of float samples actually written. A return value
+     * less than dst.size() indicates either a clean end-of-stream or a fatal
+     * source error; distinguish via error(). A fatal error may be reported
+     * after a positive short read if the backend returned partial data before
+     * surfacing the failure. Output samples are finite and clamped to [-1, 1].
+     *
+     * Implementations must throw std::invalid_argument when dst is empty or
+     * its size is not a whole multiple of channels: a contract violation is
+     * a programmer error and silently degrading to a sticky error / zero
+     * return would mask it.
+     *
+     * @param dst Destination buffer; size must be a non-empty multiple of channels.
+     * @return Number of float samples written (0 on EOF or sticky error).
+     * @throws std::invalid_argument when dst is empty or not aligned to channels.
+     */
+    [[nodiscard]] virtual std::size_t read(std::span<float> dst) = 0;
+
+    /**
+     * @brief Reset the read position to the start of the stream.
+     *
+     * Returns true on success; false if the source is not seekable or the
+     * underlying seek fails. Callers using --loop should validate
+     * seekable() at startup so a non-seekable source rejects --loop with a
+     * clear diagnostic instead of failing only after the first EOF.
+     *
+     * @return true on success, false otherwise.
+     */
+    [[nodiscard]] virtual bool rewind() = 0;
+
+    /**
+     * @brief Whether the underlying stream supports rewind().
+     *
+     * Regular file-backed sources are usually seekable; FIFO / device paths
+     * are not. Used by callers to fail fast at startup when --loop is
+     * requested over a non-seekable backing.
+     *
+     * @return true if rewind() can succeed, false otherwise.
+     */
+    [[nodiscard]] virtual bool seekable() const = 0;
+
+    /**
+     * @brief Whether this source has encountered a fatal read error.
+     *
+     * The flag is sticky: once true, the source's read state is no longer
+     * trusted. Callers should stop transmitting and report an error rather
+     * than attempting to rewind and continue.
+     *
+     * @return true if any read has encountered a fatal I/O / decoder error.
+     */
+    [[nodiscard]] virtual bool error() const = 0;
+
+protected:
+    AudioSource() = default;
+};

--- a/src/utils/audio/libsndfile_audio_source.cpp
+++ b/src/utils/audio/libsndfile_audio_source.cpp
@@ -1,0 +1,256 @@
+/**
+ * @file libsndfile_audio_source.cpp
+ * @brief libsndfile-backed AudioSource implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "libsndfile_audio_source.h"
+
+#include <sndfile.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace {
+    [[nodiscard]] float sanitizeDecodedSample(float sample) noexcept {
+        if (std::isfinite(sample) == false) {
+            return 0.0F;
+        }
+        return std::clamp(sample, -1.0F, 1.0F);
+    }
+
+    /**
+     * @brief Build a "MAJOR / SUBTYPE" description from a libsndfile SF_INFO.
+     *
+     * Two SFC_GET_FORMAT_INFO queries: one against the major-format mask
+     * (WAV, FLAC, ...) and one against the subtype mask (PCM_16, PCM_24,
+     * FLOAT, ...). Both are global queries (sf_command on a null handle),
+     * so they can run before or after the SNDFILE handle is closed.
+     *
+     * @param info Source SF_INFO populated by sf_open / sf_open_virtual.
+     * @return One-line description; "unknown" if both queries fail.
+     */
+    [[nodiscard]] std::string formatDescription(const SF_INFO& info) {
+        SF_FORMAT_INFO mainInfo{};
+        mainInfo.format = info.format & SF_FORMAT_TYPEMASK;
+        const int mainOk{sf_command(nullptr, SFC_GET_FORMAT_INFO, &mainInfo, sizeof(mainInfo))};
+
+        SF_FORMAT_INFO subInfo{};
+        subInfo.format = info.format & SF_FORMAT_SUBMASK;
+        const int subOk{sf_command(nullptr, SFC_GET_FORMAT_INFO, &subInfo, sizeof(subInfo))};
+
+        std::string result;
+        if (mainOk == 0 && mainInfo.name != nullptr) {
+            result += mainInfo.name;
+        }
+        if (subOk == 0 && subInfo.name != nullptr) {
+            if (result.empty() == false) {
+                result += " / ";
+            }
+            result += subInfo.name;
+        }
+        if (result.empty()) {
+            result = "unknown";
+        }
+        return result;
+    }
+
+    /**
+     * @brief AudioSource backed by libsndfile.
+     *
+     * Hidden implementation returned through the AudioSource interface by
+     * makeFileAudioSource().
+     */
+    class LibsndfileAudioSource final : public AudioSource {
+    public:
+        /**
+         * @brief Construct from an open backend handle.
+         *
+         * Takes ownership of handle. The format, seekable flag, and
+         * description are captured at construction time.
+         *
+         * @param handle      Open backend handle (must be non-null).
+         * @param info        Format metadata populated by the backend.
+         * @param seekable    Whether the source can seek back to the start.
+         * @param description Human-readable format description.
+         */
+        LibsndfileAudioSource(SNDFILE* handle, const SF_INFO& info, bool seekable, std::string description)
+            : handle_{handle},
+              format_{.channels = info.channels, .sampleRate = info.samplerate},
+              seekable_{seekable},
+              description_{std::move(description)} {
+            // makeFileAudioSource is the only construction site and rejects a
+            // null handle before reaching this point, so no defensive runtime
+            // check is needed here.
+        }
+
+        /**
+         * @brief Close the owned backend handle.
+         */
+        ~LibsndfileAudioSource() override {
+            if (handle_ != nullptr) {
+                sf_close(handle_);
+            }
+        }
+
+        /**
+         * @brief Return channel count and sample rate captured at open time.
+         */
+        [[nodiscard]] AudioFormat format() const override {
+            return format_;
+        }
+
+        /**
+         * @brief Return the human-readable format description captured at open time.
+         */
+        [[nodiscard]] std::string_view description() const override {
+            return description_;
+        }
+
+        /**
+         * @brief Read interleaved float samples into dst.
+         *
+         * dst.size() must be a multiple of format().channels. Samples returned
+         * by the backend are clamped to [-1, 1], and non-finite samples are
+         * replaced with silence. A fatal read or decoder error makes error()
+         * sticky.
+         *
+         * @param dst Destination sample buffer.
+         * @return Number of float samples written; 0 on EOF, prior error, or
+         *         immediate read failure. A backend error after a partial read
+         *         may return a positive count and set error().
+         */
+        [[nodiscard]] std::size_t read(std::span<float> dst) override {
+            const auto channels{static_cast<std::size_t>(format_.channels)};
+            // Surface caller contract violations as throw, matching
+            // AudioBlockReader::read and downmixInterleavedToMono: a
+            // misaligned dst is a programmer error, not a runtime
+            // condition, so degrading silently to a sticky error_ would
+            // hide the real fault under generic "source failed" telemetry.
+            if (channels == 0 || dst.empty() || dst.size() % channels != 0) {
+                throw std::invalid_argument{
+                    "LibsndfileAudioSource::read: dst must be a non-empty whole number of frames (size " +
+                    std::to_string(dst.size()) + ", channels " + std::to_string(channels) + ")"};
+            }
+
+            if (error_) {
+                return 0;
+            }
+
+            const auto framesRequested{static_cast<sf_count_t>(dst.size() / channels)};
+            const sf_count_t framesRead{sf_readf_float(handle_, dst.data(), framesRequested)};
+            if (framesRead < 0) {
+                error_ = true;
+                return 0;
+            }
+
+            // Short read at clean EOF is normal; only flag I/O errors. sf_error
+            // returns SF_ERR_NO_ERROR (0) on a clean end-of-stream, non-zero on
+            // an actual decoder / read failure.
+            if (framesRead < framesRequested && sf_error(handle_) != SF_ERR_NO_ERROR) {
+                error_ = true;
+            }
+
+            const std::size_t samplesRead{static_cast<std::size_t>(framesRead) * channels};
+            for (float& sample: dst.first(samplesRead)) {
+                sample = sanitizeDecodedSample(sample);
+            }
+            return samplesRead;
+        }
+
+        /**
+         * @brief Seek back to the start of the stream.
+         *
+         * @return false if the source is not seekable or the backend seek fails.
+         */
+        [[nodiscard]] bool rewind() override {
+            if (seekable_ == false) {
+                return false;
+            }
+            if (sf_seek(handle_, 0, SEEK_SET) < 0) {
+                error_ = true;
+                return false;
+            }
+            return true;
+        }
+
+        /**
+         * @brief Report whether the backend marked this source as seekable at open time.
+         */
+        [[nodiscard]] bool seekable() const override {
+            return seekable_;
+        }
+
+        /**
+         * @brief Report whether a fatal read or seek error has occurred.
+         */
+        [[nodiscard]] bool error() const override {
+            return error_;
+        }
+
+    private:
+        SNDFILE* handle_;
+        AudioFormat format_;
+        bool seekable_;
+        bool error_{false};
+        std::string description_;
+    };
+}  // namespace
+
+std::unique_ptr<AudioSource> makeFileAudioSource(const std::string& path) {
+    SF_INFO info{};
+    std::unique_ptr<SNDFILE, decltype(&sf_close)> handle{sf_open(path.c_str(), SFM_READ, &info), sf_close};
+    if (handle == nullptr) {
+        std::cerr << "[ERROR] Failed to open audio file '" << path << "': " << sf_strerror(nullptr) << std::endl;
+        return nullptr;
+    }
+
+    auto source{
+        std::make_unique<LibsndfileAudioSource>(handle.get(), info, info.seekable != 0, formatDescription(info))};
+    handle.release();
+    return source;
+}
+
+std::unique_ptr<AudioSource> makeStdinAudioSource() {
+    SF_INFO info{};
+    // close_desc = SF_FALSE: stdin is owned by the runtime, libsndfile must
+    // not close fd 0 on sf_close. The factory still owns the SNDFILE handle
+    // itself and releases it through sf_close as usual on destruction.
+    std::unique_ptr<SNDFILE, decltype(&sf_close)> handle{sf_open_fd(fileno(stdin), SFM_READ, &info, SF_FALSE),
+                                                         sf_close};
+    if (handle == nullptr) {
+        std::cerr << "[ERROR] Failed to open stdin as audio source: " << sf_strerror(nullptr) << std::endl;
+        return nullptr;
+    }
+
+    // Force seekable=false even when libsndfile reports otherwise (e.g. when
+    // stdin happens to be a redirected regular file). Pipe / FIFO inputs are
+    // the common case for --stdin, and treating the source uniformly as a
+    // stream lets validateLoopSupport() reject --loop with a single,
+    // consistent diagnostic instead of one that depends on how stdin was
+    // wired up at the shell.
+    auto source{
+        std::make_unique<LibsndfileAudioSource>(handle.get(), info, false, "stdin / " + formatDescription(info))};
+    handle.release();
+    return source;
+}
+
+std::unique_ptr<AudioSource> makeAudioSource(bool useStdin, const std::string& path) {
+    if (useStdin) {
+        return makeStdinAudioSource();
+    }
+    return makeFileAudioSource(path);
+}

--- a/src/utils/audio/libsndfile_audio_source.h
+++ b/src/utils/audio/libsndfile_audio_source.h
@@ -1,0 +1,68 @@
+/**
+ * @file libsndfile_audio_source.h
+ * @brief libsndfile-backed AudioSource factory function.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "audio_source.h"
+
+/**
+ * @brief Open a file-backed audio source via libsndfile.
+ *
+ * Accepts any format libsndfile is built with: WAV / AIFF / FLAC / OGG /
+ * Opus / etc. Output samples are finite floats clamped to [-1, 1] regardless
+ * of on-disk encoding (PCM_16, PCM_24, FLOAT, ...). Rewind support is taken
+ * from libsndfile metadata, so regular files can loop while FIFO / device
+ * paths fail loop validation.
+ *
+ * On failure prints a diagnostic to stderr and returns nullptr.
+ *
+ * @param path Path to the audio file.
+ * @return Owning pointer to the source on success, nullptr on failure.
+ */
+[[nodiscard]] std::unique_ptr<AudioSource> makeFileAudioSource(const std::string& path);
+
+/**
+ * @brief Open stdin as an audio source via libsndfile.
+ *
+ * Wraps `fileno(stdin)` through `sf_open_fd` with `close_desc=SF_FALSE` so
+ * libsndfile never closes the inherited stdin file descriptor on us. The
+ * resulting source is always reported as non-seekable, regardless of what
+ * libsndfile's metadata claims about the underlying fd: a pipe or terminal
+ * cannot be rewound, and even a redirected regular file is treated as a
+ * stream so that `--loop` consistently fails fast through validateLoopSupport()
+ * instead of intermittently working only when stdin happens to be a file.
+ *
+ * Practical formats: WAV / AIFF / FLAC headers can be parsed sequentially,
+ * so those usually work over a pipe. Containers that require seeking back
+ * (e.g. some Ogg / Opus muxes) may fail at open time with a libsndfile
+ * diagnostic; rerun with `--audio <path>` in that case.
+ *
+ * On failure prints a diagnostic to stderr and returns nullptr.
+ *
+ * @return Owning pointer to the source on success, nullptr on failure.
+ */
+[[nodiscard]] std::unique_ptr<AudioSource> makeStdinAudioSource();
+
+/**
+ * @brief Open either stdin or a file as an audio source, based on a flag.
+ *
+ * Thin dispatcher over makeStdinAudioSource() and makeFileAudioSource() so
+ * each transmitter binary can resolve its `--stdin` / `--audio` choice in a
+ * single call instead of repeating the same if/else at every call site.
+ *
+ * @param useStdin When true, open stdin and ignore path.
+ * @param path     Audio file path (used only when useStdin is false).
+ * @return Owning pointer to the source on success, nullptr on failure.
+ */
+[[nodiscard]] std::unique_ptr<AudioSource> makeAudioSource(bool useStdin, const std::string& path);

--- a/src/utils/audio/soxr_resampler.cpp
+++ b/src/utils/audio/soxr_resampler.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file soxr_resampler.cpp
+ * @brief libsoxr RAII wrapper implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 29.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "soxr_resampler.h"
+
+#include <soxr.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace {
+    [[nodiscard]] constexpr unsigned long qualityRecipe(SoxrResampler::Quality q) noexcept {
+        switch (q) {
+            case SoxrResampler::Quality::Quick:
+                return SOXR_QQ;
+            case SoxrResampler::Quality::Low:
+                return SOXR_LQ;
+            case SoxrResampler::Quality::Medium:
+                return SOXR_MQ;
+            case SoxrResampler::Quality::High:
+                return SOXR_HQ;
+            case SoxrResampler::Quality::VeryHigh:
+                return SOXR_VHQ;
+        }
+        return SOXR_HQ;
+    }
+}  // namespace
+
+struct SoxrResampler::Impl {
+    soxr_t handle{nullptr};
+
+    Impl(int sourceRateHz, int targetRateHz, Quality quality) {
+        if (sourceRateHz <= 0 || targetRateHz <= 0) {
+            throw std::invalid_argument{"SoxrResampler: rates must be positive"};
+        }
+
+        // Float32 interleaved both ways. With num_channels=1 interleaved and
+        // planar are bit-identical, so this is the natural single-stream layout.
+        const soxr_io_spec_t ioSpec{soxr_io_spec(SOXR_FLOAT32_I, SOXR_FLOAT32_I)};
+        const soxr_quality_spec_t qualitySpec{soxr_quality_spec(qualityRecipe(quality), 0)};
+        // Pass nullptr for the runtime spec so libsoxr applies its own defaults.
+        // soxr_runtime_spec(1) hard-codes log2_min_dft_size = 10 (1024-point DFT
+        // floor), which is larger than our per-block input on the 44.1 kHz ->
+        // 48 kHz path (941 samples) and 44.1 kHz -> 228 kHz path (793 samples);
+        // forcing that floor on undersized blocks crashed pinfm/pifmrds during
+        // the very first soxr_process call. The library-default runtime spec
+        // sizes its DFT lazily from the actual block size.
+
+        soxr_error_t error{nullptr};
+        soxr_t createdHandle{soxr_create(sourceRateHz, targetRateHz, 1, &error, &ioSpec, &qualitySpec, nullptr)};
+        if (error != nullptr || createdHandle == nullptr) {
+            if (createdHandle != nullptr) {
+                soxr_delete(createdHandle);
+            }
+            const char* msg{error != nullptr ? error : "unknown error"};
+            throw std::runtime_error{std::string{"SoxrResampler: soxr_create failed: "} + msg};
+        }
+        handle = createdHandle;
+    }
+
+    ~Impl() {
+        if (handle != nullptr) {
+            soxr_delete(handle);
+        }
+    }
+
+    Impl(const Impl&)            = delete;
+    Impl& operator=(const Impl&) = delete;
+};
+
+SoxrResampler::SoxrResampler(int sourceRateHz, int targetRateHz, Quality quality)
+    : impl_{std::make_unique<Impl>(sourceRateHz, targetRateHz, quality)} {
+}
+
+SoxrResampler::~SoxrResampler() = default;
+
+SoxrResampler::SoxrResampler(SoxrResampler&&) noexcept = default;
+
+SoxrResampler& SoxrResampler::operator=(SoxrResampler&&) noexcept = default;
+
+std::optional<SoxrProcessResult> SoxrResampler::process(std::span<const float> in, std::span<float> out) noexcept {
+    if (impl_ == nullptr || impl_->handle == nullptr) {
+        return std::nullopt;
+    }
+
+    std::size_t inputDone{0};
+    std::size_t outputDone{0};
+
+    // Hand soxr nullptr when a span is empty so we never pair a non-null
+    // pointer with size 0; an empty input span is the documented EOS flush.
+    const float* inPtr{in.empty() ? nullptr : in.data()};
+    float* outPtr{out.empty() ? nullptr : out.data()};
+
+    const soxr_error_t error{
+        soxr_process(impl_->handle, inPtr, in.size(), &inputDone, outPtr, out.size(), &outputDone)};
+    if (error != nullptr) {
+        return std::nullopt;
+    }
+    return SoxrProcessResult{.inputConsumed = inputDone, .outputProduced = outputDone};
+}
+
+void SoxrResampler::clear() noexcept {
+    if (impl_ != nullptr && impl_->handle != nullptr) {
+        soxr_clear(impl_->handle);
+    }
+}

--- a/src/utils/audio/soxr_resampler.h
+++ b/src/utils/audio/soxr_resampler.h
@@ -1,0 +1,110 @@
+/**
+ * @file soxr_resampler.h
+ * @brief RAII C++ wrapper around the libsoxr streaming resampler.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 29.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <span>
+
+/**
+ * @brief Result of a single resampling step.
+ */
+struct SoxrProcessResult {
+    std::size_t inputConsumed;   ///< Frames accepted from the input span.
+    std::size_t outputProduced;  ///< Frames written into the output span.
+};
+
+/**
+ * @brief Single-channel float streaming resampler backed by libsoxr.
+ *
+ * Exposes a C++ surface with std::span and std::optional while hiding the
+ * libsoxr C handle behind PIMPL. Non-copyable, movable so it can live in
+ * std::vector or be returned from factories.
+ */
+class SoxrResampler {
+public:
+    /**
+     * @brief Resampling quality preset.
+     *
+     * Mirrors libsoxr's quality recipes; see the libsoxr documentation for
+     * SNR / passband details.
+     */
+    enum class Quality {
+        Quick,     ///< Cheapest, ~13 dB SNR (rarely useful).
+        Low,       ///< ~67 dB SNR.
+        Medium,    ///< ~96 dB SNR; default for audio paths.
+        High,      ///< ~121 dB SNR.
+        VeryHigh,  ///< ~144 dB SNR.
+    };
+
+    /**
+     * @brief Construct a single-channel resampler for the given rate pair.
+     *
+     * @param sourceRateHz Input sample rate in Hz (> 0).
+     * @param targetRateHz Output sample rate in Hz (> 0).
+     * @param quality      Quality preset; defaults to Medium (~96 dB SNR),
+     *                     a balanced compromise between filter length and
+     *                     per-block CPU cost that fits the current
+     *                     transmitter paths on a Pi Zero. Use High if
+     *                     measurements show audible resampling artefacts.
+     *
+     * @throws std::invalid_argument when either rate is non-positive.
+     * @throws std::runtime_error    when libsoxr rejects the configuration.
+     */
+    SoxrResampler(int sourceRateHz, int targetRateHz, Quality quality = Quality::Medium);
+
+    ~SoxrResampler();
+
+    SoxrResampler(const SoxrResampler&)            = delete;
+    SoxrResampler& operator=(const SoxrResampler&) = delete;
+
+    SoxrResampler(SoxrResampler&& other) noexcept;
+    SoxrResampler& operator=(SoxrResampler&& other) noexcept;
+
+    /**
+     * @brief Run one streaming resampling step.
+     *
+     * The backend returns when either the input is exhausted
+     * (inputConsumed == in.size) or the output buffer is full
+     * (outputProduced == out.size). The caller MUST inspect inputConsumed - if
+     * it is less than in.size the surplus input remains the caller's
+     * responsibility; sizing the staging output buffer for the maximum output
+     * the rate ratio can yield guarantees inputConsumed == in.size so no input
+     * is dropped.
+     *
+     * Passing an empty input span is libsoxr's documented end-of-stream
+     * flush form; do NOT use it mid-stream because subsequent calls with
+     * fresh input desynchronise the resampler's filter delay line and
+     * collapse the output toward silence.
+     *
+     * @param in  Input frames (empty only at end-of-stream).
+     * @param out Output buffer.
+     * @return Frame counts on success; std::nullopt when libsoxr reports
+     *         an error.
+     */
+    [[nodiscard]] std::optional<SoxrProcessResult> process(std::span<const float> in, std::span<float> out) noexcept;
+
+    /**
+     * @brief Reset the internal filter delay line and phase.
+     *
+     * Leaves the configured rate / quality untouched but empties any sample
+     * buffered inside the resampler. Use this at loop boundaries so the filter
+     * tail of the previous file iteration does not smear into the start of the
+     * next one.
+     */
+    void clear() noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};

--- a/src/utils/cli/CMakeLists.txt
+++ b/src/utils/cli/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 29.04.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Shared CLI parsing utility library
+# ----------------------------------------------------------
+# Provides the command-line front-end shared by every migrated transmitter
+# binary: a thin CLI11 wrapper that routes help to stdout and parse errors
+# to stderr, a frequency parser that accepts decimal and scientific notation
+# resolving to integer Hz, and reusable CLI11 validators bound to a uniform
+# ParseResult outcome enum.
+# ----------------------------------------------------------
+find_package(CLI11 CONFIG REQUIRED)
+add_library(rpitx_cli_utils STATIC
+    cli_common.cpp
+    cli_validators.cpp
+)
+target_include_directories(rpitx_cli_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(rpitx_cli_utils PUBLIC CLI11::CLI11)

--- a/src/utils/cli/cli_common.cpp
+++ b/src/utils/cli/cli_common.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file cli_common.cpp
+ * @brief Implementation of the CLI11 helpers shared by migrated binaries.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 28.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "cli_common.h"
+
+#include <charconv>
+#include <cmath>
+#include <iostream>
+#include <system_error>
+
+namespace rpitx::cli {
+    std::optional<std::uint64_t> parseFrequencyHz(std::string_view text) noexcept {
+        if (text.empty()) {
+            return std::nullopt;
+        }
+
+        // std::from_chars on double accepts decimal and scientific notation
+        // in a locale-independent, allocation-free way. The full input must
+        // be consumed; trailing garbage is rejected.
+        double value{};
+        const auto first{text.data()};
+        const auto last{first + text.size()};
+        if (const auto [ptr, ec]{std::from_chars(first, last, value)}; ec != std::errc{} || ptr != last) {
+            return std::nullopt;
+        }
+
+        // UINT64_MAX (2^64 - 1) is not exactly representable in double;
+        // 0x1p64 is exactly 2^64 and is the strict upper bound any finite
+        // double can convert safely to uint64_t from.
+        if (std::isfinite(value) == false || value <= 0.0 || value >= 0x1p64) {
+            return std::nullopt;
+        }
+
+        // Reject fractional Hz: the internal carrier frequency parameter is
+        // stored as integer Hz, and silently truncating fractional parts
+        // would mask user mistakes (e.g. forgetting a trailing 'e6').
+        double intpart{};
+        if (std::modf(value, &intpart) != 0.0) {
+            return std::nullopt;
+        }
+
+        return static_cast<std::uint64_t>(value);
+    }
+
+    ParseResult parseCliApp(CLI::App& app, int argc, char* argv[]) {
+        try {
+            app.parse(argc, argv);
+        } catch (const CLI::CallForHelp&) {
+            std::cout << app.help();
+            return ParseResult::Help;
+        } catch (const CLI::ParseError& e) {
+            std::cerr << "[ERROR] " << e.what() << std::endl;
+            std::cerr << app.help();
+            return ParseResult::Error;
+        }
+        return ParseResult::Ok;
+    }
+
+    ParseResult assignFrequencyHz(std::string_view text, std::uint64_t& out) {
+        const auto parsed{parseFrequencyHz(text)};
+        if (parsed == std::nullopt) {
+            std::cerr << "[ERROR] Invalid --freq: '" << text << "'" << std::endl;
+            return ParseResult::Error;
+        }
+        out = parsed.value();
+        return ParseResult::Ok;
+    }
+}  // namespace rpitx::cli

--- a/src/utils/cli/cli_common.h
+++ b/src/utils/cli/cli_common.h
@@ -1,0 +1,76 @@
+/**
+ * @file cli_common.h
+ * @brief Shared CLI11 helpers used by migrated rpitx-ui binaries.
+ *
+ * Provides a small, deliberately thin wrapper around CLI11 that centralizes
+ * the parts of the CLI v2 contract that every migrated binary must enforce:
+ *   - help output goes to stdout (CLI11 default -h / --help, both accepted),
+ *   - parse errors go to stderr,
+ *   - --freq is parsed via parseFrequencyHz so that decimal/scientific
+ *     notation that resolves to integer Hz is accepted while fractional Hz
+ *     and out-of-range values are rejected.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 28.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <CLI/CLI.hpp>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include "cli_parse_result.h"
+
+namespace rpitx::cli {
+    /**
+     * @brief Parse a textual frequency value into integer Hz.
+     *
+     * Accepts integer decimal notation (100000000), scientific notation
+     * (100e6), and decimal/scientific values whose mathematical result is
+     * integer-valued in Hz (100.0e6, 100.5e6 -> 100500000). Fractional Hz
+     * values (e.g. 100.5) are rejected because the internal carrier
+     * frequency parameter is stored as integer Hz.
+     *
+     * Rejects empty input, non-finite values, values <= 0, values >= 2^64,
+     * and values that do not resolve to an integer Hz quantity.
+     *
+     * @param text Textual frequency value from the command line.
+     * @return Parsed value in Hz on success, std::nullopt on failure.
+     */
+    [[nodiscard]] std::optional<std::uint64_t> parseFrequencyHz(std::string_view text) noexcept;
+
+    /**
+     * @brief Parse a configured CLI11 application and translate the outcome into a ParseResult.
+     *
+     * Catches CLI::CallForHelp and prints help to stdout (exit cleanly).
+     * Catches CLI::ParseError and prints the diagnostic plus help to stderr
+     * (exit non-zero). Any other exception is allowed to propagate so that
+     * the harness can surface it as a fatal error.
+     *
+     * @param app  Configured CLI11 application.
+     * @param argc argc as received by main.
+     * @param argv argv as received by main.
+     * @return ParseResult::Ok on success, ::Help if --help was requested,
+     *         ::Error on parse failure.
+     */
+    [[nodiscard]] ParseResult parseCliApp(CLI::App& app, int argc, char* argv[]);
+
+    /**
+     * @brief Convert a captured frequency string into integer Hz.
+     *
+     * Convenience wrapper around parseFrequencyHz that emits a uniform
+     * "[ERROR] Invalid --freq: '...'" diagnostic on failure and returns
+     * ParseResult::Error so the caller can short-circuit cleanly.
+     *
+     * @param text  Textual frequency value captured by CLI11.
+     * @param out   Output - assigned the parsed value on success.
+     * @return ParseResult::Ok on success, ::Error on parse failure
+     *         (diagnostic already printed to stderr).
+     */
+    [[nodiscard]] ParseResult assignFrequencyHz(std::string_view text, std::uint64_t& out);
+}  // namespace rpitx::cli

--- a/src/utils/cli/cli_parse_result.h
+++ b/src/utils/cli/cli_parse_result.h
@@ -1,0 +1,27 @@
+/**
+ * @file cli_parse_result.h
+ * @brief CLI parse outcome shared across migrated rpitx-ui tools.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 28.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+namespace rpitx::cli {
+    /**
+     * @brief Outcome of command-line argument parsing for migrated rpitx-ui tools.
+     *
+     * Distinguishes a successful parse, a user-visible error, and a help
+     * request so that the caller can exit with a proper status code (0 for
+     * Help, non-zero for Error) without extra sentinels.
+     */
+    enum class ParseResult {
+        Ok,     ///< Options successfully populated.
+        Error,  ///< Invalid arguments; caller should exit with non-zero code.
+        Help,   ///< User requested help (--help); caller should exit cleanly.
+    };
+}  // namespace rpitx::cli

--- a/src/utils/cli/cli_validators.cpp
+++ b/src/utils/cli/cli_validators.cpp
@@ -1,0 +1,51 @@
+/**
+ * @file cli_validators.cpp
+ * @brief Implementations of the reusable CLI11 validators.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 28.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "cli_validators.h"
+
+#include <charconv>
+#include <cmath>
+#include <string>
+#include <system_error>
+
+#include "cli_common.h"
+
+namespace rpitx::cli::validators {
+    // CLI::Validator(callback, desc, name): the callback returns "" on success
+    // or a diagnostic on failure (CLI11 prepends the option name when raising
+    // the ParseError, so the message describes only the violated constraint).
+    // desc and name are deliberately empty so help reads "--freq TEXT REQUIRED"
+    // rather than "--freq TEXT:... REQUIRED" - the option's own description
+    // already explains the value.
+    const CLI::Validator PositiveFiniteFloat{
+        [](const std::string& text) -> std::string {
+            float value{};
+            const auto first{text.data()};
+            const auto last{first + text.size()};
+            if (const auto [ptr, ec]{std::from_chars(first, last, value)};
+                ptr != last || ec == std::errc::invalid_argument) {
+                return "must be a numeric value";
+            } else if (ec == std::errc::result_out_of_range || std::isfinite(value) == false || value <= 0.0F) {
+                return "must be a positive finite float";
+            }
+            return {};
+        },
+        ""};
+
+    const CLI::Validator FrequencyHz{
+        [](const std::string& text) -> std::string {
+            if (parseFrequencyHz(text) == std::nullopt) {
+                return "must be a positive integer Hz value (decimal or scientific notation, e.g. 100000000 or 100e6)";
+            }
+            return {};
+        },
+        ""};
+}  // namespace rpitx::cli::validators

--- a/src/utils/cli/cli_validators.h
+++ b/src/utils/cli/cli_validators.h
@@ -1,0 +1,43 @@
+/**
+ * @file cli_validators.h
+ * @brief Reusable CLI11 validators shared by migrated rpitx-ui binaries.
+ *
+ * Only validators that are genuinely shared across more than one migrated
+ * binary live here. Module-specific rules (RDS PS/RT/PI lengths, the
+ * pirfgen mode/tone-count relationship, the pichirp sweep period limits,
+ * the pimorse message policy, the pissb sideband choice) intentionally
+ * remain near their module so that opening the module file makes its
+ * full CLI surface visible.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 28.04.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <CLI/CLI.hpp>
+
+namespace rpitx::cli::validators {
+    /**
+     * @brief Validator that accepts only positive finite float values.
+     *
+     * Rejects zero, negatives, NaN, +-infinity, and values that cannot be
+     * represented as a positive finite float. Intended for options such as
+     * --bandwidth, --sweep-time, and --wpm where the downstream algorithm
+     * stores the parsed value as float.
+     */
+    extern const CLI::Validator PositiveFiniteFloat;
+
+    /**
+     * @brief Validator that accepts only textual frequency values that
+     *        resolve to integer Hz.
+     *
+     * Backs --freq across all migrated transmitter binaries. Defers to
+     * parseFrequencyHz so the accepted/rejected set stays in lock-step
+     * with the post-parse conversion.
+     */
+    extern const CLI::Validator FrequencyHz;
+}  // namespace rpitx::cli::validators

--- a/src/utils/dsp/CMakeLists.txt
+++ b/src/utils/dsp/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 02.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Shared DSP utility library
+# ----------------------------------------------------------
+# Provides the lightweight signal-processing primitives shared by every
+# transmitter binary: an envelope-tracking automatic gain control (AGC) that
+# usable with both IqSample pairs and scalar audio, a Direct-Form-I
+# second-order IIR Biquad with Butterworth high/low-pass and FM
+# pre-emphasis factories, a Blackman-windowed Hilbert FIR transformer that
+# turns a real input into a delay-aligned analytic (I/Q) signal, and the
+# common IqSample value type that ties these stages together into a
+# pipeline.
+# ----------------------------------------------------------
+add_library(rpitx_dsp_utils STATIC
+    biquad.cpp
+    hilbert.cpp
+)
+target_include_directories(rpitx_dsp_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(rpitx_dsp_utils PRIVATE m)

--- a/src/utils/dsp/agc.h
+++ b/src/utils/dsp/agc.h
@@ -1,0 +1,113 @@
+/**
+ * @file agc.h
+ * @brief Fast automatic gain control (AGC) for IQ and real-valued audio signals.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include "iq_sample.h"
+
+/**
+ * @brief Configuration parameters for the AGC.
+ *
+ * All fields must be explicitly provided - no domain-specific defaults.
+ *
+ * @code
+ * Agc agc{{.target = 0.8f, .attack = 0.1f, .decay = 0.001f, .initialEnvelope = 1e-4f}};
+ * @endcode
+ */
+struct AgcConfig {
+    float target;           ///< Target output amplitude.
+    float attack;           ///< Envelope attack coefficient (fast response to level increase).
+    float decay;            ///< Envelope decay coefficient (slow response to level decrease).
+    float initialEnvelope;  ///< Initial envelope estimate.
+};
+
+/**
+ * @brief Fast envelope-tracking AGC for IQ sample pairs or scalar audio samples.
+ *
+ * Tracks the signal envelope with asymmetric attack/decay smoothing
+ * and applies gain to maintain a constant output amplitude. The internal
+ * envelope state is shared between the IQ and scalar overloads, so a
+ * single instance is intended to be used for one signal domain at a time.
+ *
+ * @code
+ * Agc agc{{.target = 0.8f, .attack = 0.1f, .decay = 0.001f, .initialEnvelope = 1e-4f}};
+ * auto normalized{agc.process(iq)};
+ * @endcode
+ */
+class Agc {
+public:
+    /**
+     * @brief Construct an AGC with the given configuration.
+     * @param config AGC parameters.
+     */
+    explicit Agc(AgcConfig config) noexcept
+        : target_{config.target}, attack_{config.attack}, decay_{config.decay}, env_{config.initialEnvelope} {
+    }
+
+    /**
+     * @brief Apply AGC to an IQ sample pair.
+     * @param sample Input IQ sample.
+     * @return Gain-adjusted IQ sample.
+     */
+    [[nodiscard]] IqSample process(IqSample sample) noexcept {
+        const float gain{updateGain(std::hypot(sample.i, sample.q))};
+        return {
+            .i = sample.i * gain,
+            .q = sample.q * gain,
+        };
+    }
+
+    /**
+     * @brief Apply AGC to a real-valued audio sample.
+     * @param sample Input scalar sample.
+     * @return Gain-adjusted scalar sample.
+     */
+    [[nodiscard]] float process(float sample) noexcept {
+        return sample * updateGain(std::abs(sample));
+    }
+
+    /**
+     * @brief Advance the envelope estimate from an externally-computed
+     *        magnitude and return the gain to apply.
+     *
+     * Use this when a single shared gain must be applied to several
+     * correlated channels (e.g. stereo L / R driven from max(|L|, |R|)
+     * so the inter-channel level relationship is preserved). Each call
+     * advances the envelope state exactly as the process() overloads do,
+     * so do not mix updateGain() and process() calls on the same instance
+     * within one sample step.
+     *
+     * @param mag Current sample magnitude (|i+jq| for IQ, |x| for scalar,
+     *            max(|L|, |R|) for shared-gain stereo). Must be >= 0.
+     * @return Gain factor target / env, clamped to 1.0 when env is near zero.
+     */
+    [[nodiscard]] float updateGain(float mag) noexcept {
+        // Asymmetric attack/decay envelope tracker.
+        if (mag > env_) {
+            env_ += attack_ * (mag - env_);
+        } else {
+            env_ += decay_ * (mag - env_);
+        }
+
+        if (env_ > 1e-6f) {
+            return target_ / env_;
+        }
+        return 1.0f;
+    }
+
+private:
+    float target_;  ///< Target output amplitude.
+    float attack_;  ///< Envelope attack coefficient.
+    float decay_;   ///< Envelope decay coefficient.
+    float env_;     ///< Current envelope estimate.
+};

--- a/src/utils/dsp/biquad.cpp
+++ b/src/utils/dsp/biquad.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file biquad.cpp
+ * @brief Biquad filter implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "biquad.h"
+
+#include <cmath>
+#include <numbers>
+
+namespace {
+
+    /**
+     * @brief Common RBJ-cookbook intermediate quantities for low/high-pass sections.
+     */
+    struct RbjParams {
+        float cosW0;  ///< cos(omega_0).
+        float alpha;  ///< sin(omega_0) / (2 * Q).
+        float a0;     ///< Unnormalised feedback coefficient a0 = 1 + alpha.
+    };
+
+    /**
+     * @brief Compute the shared RBJ biquad design quantities.
+     * @param cutoffHz   Cutoff frequency in Hz.
+     * @param sampleRate Sample rate in Hz.
+     * @param q          Pole-pair quality factor; must be strictly positive.
+     * @return Filled RbjParams.
+     */
+    [[nodiscard]] RbjParams rbjParams(float cutoffHz, float sampleRate, float q) noexcept {
+        const float w0{2.0f * std::numbers::pi_v<float> * cutoffHz / sampleRate};
+        const float alpha{std::sin(w0) / (2.0f * q)};
+        return {
+            .cosW0 = std::cos(w0),
+            .alpha = alpha,
+            .a0    = 1.0f + alpha,
+        };
+    }
+
+}  // namespace
+
+Biquad Biquad::highPass(float cutoffHz, float sampleRate, float q) noexcept {
+    const auto [cosW0, alpha, a0]{rbjParams(cutoffHz, sampleRate, q)};
+    const float onePlusCosOverA0{(1.0f + cosW0) / a0};
+
+    return Biquad{
+        onePlusCosOverA0 / 2.0f,
+        -onePlusCosOverA0,
+        onePlusCosOverA0 / 2.0f,
+        -2.0f * cosW0 / a0,
+        (1.0f - alpha) / a0,
+    };
+}
+
+Biquad Biquad::lowPass(float cutoffHz, float sampleRate, float q) noexcept {
+    const auto [cosW0, alpha, a0]{rbjParams(cutoffHz, sampleRate, q)};
+    const float oneMinusCosOverA0{(1.0f - cosW0) / a0};
+
+    return Biquad{
+        oneMinusCosOverA0 / 2.0f,
+        oneMinusCosOverA0,
+        oneMinusCosOverA0 / 2.0f,
+        -2.0f * cosW0 / a0,
+        (1.0f - alpha) / a0,
+    };
+}
+
+Biquad Biquad::preEmphasis(float tauSeconds, float sampleRate, float boost) noexcept {
+    // Bilinear transform of H(s) = (1 + s*tau_z) / (1 + s*tau_p) with
+    //   tau_z = tauSeconds          (zero -> +6 dB/oct shelf onset)
+    //   tau_p = tauSeconds / boost  (pole -> high-frequency plateau)
+    // The resulting digital filter is first-order; it is laid out as a
+    // Biquad with b2 = a2 = 0 so it shares the Direct-Form-I run-time path
+    // with the second-order shelves. K = 2 * Fs is the standard bilinear
+    // pre-warp factor; no further frequency warping is applied because
+    // broadcast pre-emphasis is specified by time constant rather than by
+    // a precise corner frequency.
+    const float k{2.0f * sampleRate};
+    const float tauP{tauSeconds / boost};
+    const float a0{1.0f + k * tauP};
+
+    return Biquad{
+        (1.0f + k * tauSeconds) / a0,
+        (1.0f - k * tauSeconds) / a0,
+        0.0f,
+        (1.0f - k * tauP) / a0,
+        0.0f,
+    };
+}

--- a/src/utils/dsp/biquad.h
+++ b/src/utils/dsp/biquad.h
@@ -1,0 +1,126 @@
+/**
+ * @file biquad.h
+ * @brief Second-order IIR (biquad) filter for audio signal processing.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <numbers>
+
+/**
+ * @brief Second-order IIR biquad filter (Direct Form I).
+ *
+ * Provides Butterworth high-pass and low-pass factories with a configurable
+ * pole-pair Q. The Q parameter defaults to the 2nd-order Butterworth value
+ * and can be overridden for use as one section of a cascaded higher-order
+ * design (Chebyshev, Bessel, or staggered Butterworth poles). Coefficients
+ * are pre-normalized by a0 during construction.
+ *
+ * @code
+ * auto hpf{Biquad::highPass(300.0f, 48'000.0f)};                       // 2nd-order Butterworth
+ * auto lpf{Biquad::lowPass(3'000.0f, 48'000.0f, 0.5412f)};             // section of a 4th-order cascade
+ * float filtered{hpf.process(sample)};
+ * @endcode
+ */
+class Biquad {
+public:
+    /**
+     * @brief 2nd-order Butterworth pole-pair Q (1/sqrt(2)).
+     *
+     * Exposed so callers can keep the Butterworth default reference in sight
+     * when constructing custom-Q cascades (e.g. "my section 1 Q vs. the
+     * nominal Butterworth Q") without hard-coding 0.7071 at the call site.
+     */
+    static constexpr float BUTTERWORTH_Q{1.0f / std::numbers::sqrt2_v<float>};
+
+    /**
+     * @brief Create a high-pass biquad section.
+     *
+     * The pole-pair Q is the classical IIR biquad design parameter controlling
+     * the transition-band behaviour; leave it at BUTTERWORTH_Q for a standalone
+     * 2nd-order Butterworth, or pass the per-section Q from a higher-order
+     * prototype to use this instance as one stage of a cascade.
+     *
+     * @param cutoffHz Cutoff frequency in Hz.
+     * @param sampleRate Sample rate in Hz.
+     * @param q Pole-pair quality factor; must be strictly positive. Defaults to BUTTERWORTH_Q.
+     * @return Configured high-pass Biquad instance.
+     */
+    [[nodiscard]] static Biquad highPass(float cutoffHz, float sampleRate, float q = BUTTERWORTH_Q) noexcept;
+
+    /**
+     * @brief Create a low-pass biquad section.
+     *
+     * @param cutoffHz Cutoff frequency in Hz.
+     * @param sampleRate Sample rate in Hz.
+     * @param q Pole-pair quality factor; must be strictly positive. Defaults to BUTTERWORTH_Q.
+     * @return Configured low-pass Biquad instance.
+     */
+    [[nodiscard]] static Biquad lowPass(float cutoffHz, float sampleRate, float q = BUTTERWORTH_Q) noexcept;
+
+    /**
+     * @brief Create a first-order FM pre-emphasis filter as a Biquad.
+     *
+     * Implements the broadcast-FM pre-emphasis transfer function
+     * H(s) = (1 + s*tau) / (1 + s*tau / boost), bilinear-transformed to
+     * the digital domain. The shelf rises at +6 dB/oct from f_low =
+     * 1/(2 pi tau) up to a high-frequency plateau at boost (in linear
+     * units), so the audio is amplified above the corner frequency before
+     * being radiated and the matching de-emphasis at the receiver restores
+     * a flat response while attenuating the FM detector noise floor.
+     *
+     * Time-constant convention:
+     *   - 50 us: ITU regions 1 / 3 (Europe, Africa, Asia, Oceania)
+     *   - 75 us: ITU region 2 (Americas) and Japan
+     *
+     * The high-frequency plateau is configurable but defaults to a typical
+     * commercial-exciter value (boost = 16, ~24 dB) - large enough that the
+     * upper-knee corner (boost / (2 pi tau)) sits well above the 15 kHz
+     * audio mask, so within the audio band the shelf is still rising at
+     * +6 dB/oct rather than already plateauing. Realised as a first-order
+     * IIR (b2 = a2 = 0) so it shares Biquad's Direct-Form-I run-time path
+     * and per-sample state without paying for a second-order's storage.
+     *
+     * @param tauSeconds Pre-emphasis time constant (5e-5 or 7.5e-5).
+     * @param sampleRate Sample rate in Hz.
+     * @param boost      Linear high-frequency plateau gain; must be > 1.
+     * @return Configured pre-emphasis Biquad instance.
+     */
+    [[nodiscard]] static Biquad preEmphasis(float tauSeconds, float sampleRate, float boost = 16.0f) noexcept;
+
+    /**
+     * @brief Process a single input sample through the filter.
+     * @param in Input sample.
+     * @return Filtered output sample.
+     */
+    [[nodiscard]] float process(float in) noexcept {
+        const float out{b0_ * in + b1_ * x1_ + b2_ * x2_ - a1_ * y1_ - a2_ * y2_};
+
+        x2_ = x1_;
+        x1_ = in;
+        y2_ = y1_;
+        y1_ = out;
+
+        return out;
+    }
+
+private:
+    Biquad(float b0, float b1, float b2, float a1, float a2) noexcept : b0_{b0}, b1_{b1}, b2_{b2}, a1_{a1}, a2_{a2} {
+    }
+
+    float b0_;    ///< Feedforward coefficient b0.
+    float b1_;    ///< Feedforward coefficient b1.
+    float b2_;    ///< Feedforward coefficient b2.
+    float a1_;    ///< Feedback coefficient a1.
+    float a2_;    ///< Feedback coefficient a2.
+    float x1_{};  ///< Input delay z^-1.
+    float x2_{};  ///< Input delay z^-2.
+    float y1_{};  ///< Output delay z^-1.
+    float y2_{};  ///< Output delay z^-2.
+};

--- a/src/utils/dsp/hilbert.cpp
+++ b/src/utils/dsp/hilbert.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file hilbert.cpp
+ * @brief Hilbert transform FIR filter implementation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include "hilbert.h"
+
+#include <cmath>
+#include <numbers>
+#include <stdexcept>
+
+namespace {
+
+    /**
+     * @brief Validate the FIR tap count for the Hilbert transformer.
+     * @param taps Requested number of taps.
+     * @return @p taps unchanged on success.
+     * @throws std::invalid_argument When @p taps is even or smaller than 3.
+     */
+    int validateTaps(int taps) {
+        if (taps < 3 || taps % 2 == 0) {
+            throw std::invalid_argument("Hilbert tap count must be odd and >= 3");
+        }
+        return taps;
+    }
+
+}  // namespace
+
+Hilbert::Hilbert(int taps)
+    : taps_{validateTaps(taps)},
+      delay_{(taps_ - 1) / 2},
+      coeffs_(taps_, 0.0f),
+      hilbertLine_(taps_, 0.0f),
+      delayLine_(taps_, 0.0f) {
+    // Hilbert FIR coefficients with Blackman window. Even-indexed taps
+    // (relative to the centre) are zero by definition of the ideal Hilbert
+    // response, leaving only odd-indexed taps to carry the 2/(pi*k) kernel.
+    constexpr float pi{std::numbers::pi_v<float>};
+    const float denom{static_cast<float>(taps_ - 1)};
+
+    for (int n{0}; n < taps_; ++n) {
+        const int k{n - delay_};
+
+        if ((k & 1) == 0) {
+            continue;
+        }
+
+        const float w{0.42f - 0.5f * std::cos(2.0f * pi * n / denom) + 0.08f * std::cos(4.0f * pi * n / denom)};
+        coeffs_[n] = (2.0f / (pi * k)) * w;
+    }
+}
+
+IqSample Hilbert::process(float in) noexcept {
+    hilbertLine_[pos_] = in;
+    delayLine_[pos_]   = in;
+
+    // FIR convolution for the Q channel (Hilbert-transformed).
+    float qAcc{0.0f};
+    int idx{pos_};
+    for (int i{0}; i < taps_; ++i) {
+        qAcc += coeffs_[i] * hilbertLine_[idx];
+        if (--idx < 0) {
+            idx = taps_ - 1;
+        }
+    }
+
+    // I channel: delayed by delay_ samples to match the Hilbert group delay.
+    idx = pos_ - delay_;
+    if (idx < 0) {
+        idx += taps_;
+    }
+
+    const IqSample result{
+        .i = delayLine_[idx],
+        .q = qAcc,
+    };
+
+    pos_ = (pos_ + 1) % taps_;
+
+    return result;
+}

--- a/src/utils/dsp/hilbert.h
+++ b/src/utils/dsp/hilbert.h
@@ -1,0 +1,81 @@
+/**
+ * @file hilbert.h
+ * @brief Hilbert transform FIR filter for analytic signal generation.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "iq_sample.h"
+
+/**
+ * @brief Hilbert FIR transformer with Blackman window.
+ *
+ * Produces an analytic signal (I + jQ) from a real input.
+ * The I channel is delayed to match the group delay of the
+ * FIR Hilbert filter on the Q channel.
+ *
+ * The number of filter taps is specified at construction time,
+ * allowing callers to trade precision/sidelobe suppression
+ * against memory usage and group delay.
+ *
+ * @code
+ * Hilbert hilbert{255};
+ * auto iq{hilbert.process(sample)};
+ * @endcode
+ */
+class Hilbert {
+public:
+    /**
+     * @brief Default number of FIR filter taps.
+     */
+    static constexpr int DEFAULT_TAPS{255};
+
+    /**
+     * @brief Construct the Hilbert transformer and compute FIR coefficients.
+     *
+     * Coefficients use a Blackman window for sidelobe suppression.
+     * Only odd-indexed taps (relative to center) are non-zero.
+     *
+     * @param taps Number of FIR filter taps (must be odd and >= 3).
+     */
+    explicit Hilbert(int taps = DEFAULT_TAPS);
+
+    /**
+     * @brief Get the group delay in samples ((taps - 1) / 2).
+     * @return Group delay.
+     */
+    [[nodiscard]] int delay() const noexcept {
+        return delay_;
+    }
+
+    /**
+     * @brief Get the number of filter taps.
+     * @return Tap count.
+     */
+    [[nodiscard]] int taps() const noexcept {
+        return taps_;
+    }
+
+    /**
+     * @brief Process a single input sample and produce an analytic signal pair.
+     * @param in Real-valued input sample.
+     * @return IqSample with delayed I and Hilbert-transformed Q.
+     */
+    [[nodiscard]] IqSample process(float in) noexcept;
+
+private:
+    int taps_;                        ///< Number of FIR filter taps.
+    int delay_;                       ///< Group delay in samples.
+    std::vector<float> coeffs_;       ///< Hilbert FIR coefficients.
+    std::vector<float> hilbertLine_;  ///< Circular buffer for Q FIR convolution.
+    std::vector<float> delayLine_;    ///< Circular buffer for I delay line.
+    int pos_{};                       ///< Current write position in circular buffers.
+};

--- a/src/utils/dsp/iq_sample.h
+++ b/src/utils/dsp/iq_sample.h
@@ -1,0 +1,20 @@
+/**
+ * @file iq_sample.h
+ * @brief In-phase / quadrature sample pair used throughout the DSP pipeline.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 27.03.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+/**
+ * @brief In-phase / quadrature sample pair.
+ */
+struct IqSample {
+    float i{};  ///< In-phase component.
+    float q{};  ///< Quadrature component.
+};


### PR DESCRIPTION
### Problem description

The **rpitx-ui** source tree had a single flat `src/utils/` directory mixing DSP primitives (`agc`, `biquad`, `hilbert`, `iq_sample`), audio I/O helpers (`wav_utils`, `morse_encoder`, `sawtooth`), and CLI parsing helpers (`cli_utils`) into one `rpitx_utils` static library. There was no dedicated audio-pipeline abstraction (block reading, rate conversion, file/stdin sources), no shared CLI parsing/validation layer built on top of CLI11, and no separation between the DSP, audio, and CLI concerns at the CMake target level.

That made it impossible to pull only the DSP pieces into a transmitter that does not need WAV decoding, to share an audio-pipeline implementation across `piam`/`pinfm`/`pifmrds`/`pissb`, or to evolve the CLI surface (validators, parse-result helpers) without touching the existing `cli_utils.{h,cpp}` consumed across the project. The shared third-party dependencies (`libsoxr` for resampling, `libcli11-dev` for CLI parsing, `pkg-config` for locating `libsndfile`/`libsoxr` from CMake) were also not part of `install.sh`.

### Fix description

#### Shared DSP utility library
- **src/utils/dsp/CMakeLists.txt**: Added a standalone `rpitx_dsp_utils` static library target (compiles `biquad.cpp` and `hilbert.cpp`, links against `m`) with public include directory `src/utils/dsp/`.
- **src/utils/dsp/agc.h**: Added a header-only envelope-tracking AGC (`Agc` + `AgcConfig`) usable with both `IqSample` pairs and scalar audio.
- **src/utils/dsp/biquad.{h,cpp}**: Added a Direct-Form-I second-order IIR `Biquad` helper with Butterworth high/low-pass and FM pre-emphasis factories, exposing an explicit pole-pair Q parameter for higher-order Butterworth cascades.
- **src/utils/dsp/hilbert.{h,cpp}**: Added a Blackman-windowed FIR `Hilbert` transformer that turns a real input into a delay-aligned analytic (I/Q) signal.
- **src/utils/dsp/iq_sample.h**: Added the header-only `IqSample` POD type that ties the DSP and audio stages together.

#### Shared audio utility library
- **src/utils/audio/CMakeLists.txt**: Added a standalone `rpitx_audio_utils` static library target. Locates `sndfile` and `soxr` through `pkg_check_modules` (`PkgConfig::SNDFILE`, `PkgConfig::SOXR`) with public include directory `src/utils/audio/`.
- **src/utils/audio/audio_source.h**: Added the abstract `AudioSource` interface plus `AudioFormat` describing block-based PCM reads with channel-count and sample-rate metadata and rewind capability.
- **src/utils/audio/libsndfile_audio_source.{h,cpp}**: Added a `libsndfile`-backed `AudioSource` implementation with three factories — `makeFileAudioSource` (any libsndfile-supported format), `makeStdinAudioSource` (forces non-seekable so `--loop` fails fast), and a `makeAudioSource(useStdin, path)` dispatcher used by transmitter binaries to resolve their `--stdin` / `--audio` choice in a single call.
- **src/utils/audio/audio_pipeline.{h,cpp}**: Added the `AudioPipeline` (source → loop-aware block reader → channel adapter → per-channel rate conversion) that delivers fixed-size interleaved float blocks at the caller's target sample rate. Supports `AudioChannelMode::Preserve` / `AudioChannelMode::Mono`, optional looping (with crossfade in the underlying block reader), and `AudioPipelineStatus` (`Ok` / `End` / `Error`) outcomes. Also exposes shared `validateAudioFormat` and `validateLoopSupport` helpers.
- **src/utils/audio/audio_rate_converter.{h,cpp}**: Added a single-channel streaming `AudioRateConverter` that wraps `SoxrResampler` behind a fixed-size output-block contract; uses a Bresenham accumulator only to size the per-call input span exactly to the rate ratio so libsoxr always consumes the full input and the per-call output jitter is absorbed by an internal spill. Degrades to a memory copy when source and target rates match.
- **src/utils/audio/soxr_resampler.{h,cpp}**: Added a RAII `SoxrResampler` C++ wrapper around the libsoxr streaming resampler. Hides the C handle behind PIMPL, exposes a `std::span` / `std::optional` surface, and supports a configurable libsoxr quality preset.

#### Shared CLI utility library
- **src/utils/cli/CMakeLists.txt**: Added a standalone `rpitx_cli_utils` static library target. Locates CLI11 via `find_package(CLI11 CONFIG REQUIRED)` and links it as a public dependency, with public include directory `src/utils/cli/`.
- **src/utils/cli/cli_common.{h,cpp}**: Added shared CLI11 helpers in the `rpitx::cli` namespace — a thin CLI11 wrapper that routes help to stdout and parse errors to stderr, plus the `parseFrequencyHz` helper (the floating-point `std::from_chars` based parser referenced by the GCC version check in the root `CMakeLists.txt`) that accepts decimal/scientific notation resolving to integer Hz.
- **src/utils/cli/cli_validators.{h,cpp}**: Added two reusable CLI11 validators in the `rpitx::cli::validators` namespace — `PositiveFiniteFloat` (rejects zero, negatives, NaN, ±infinity) and `FrequencyHz` (defers to `parseFrequencyHz`). Module-specific validators intentionally stay near their respective module.
- **src/utils/cli/cli_parse_result.h**: Added the `rpitx::cli::ParseResult` enum (`Ok` / `Error` / `Help`) so `main` can map a parse outcome to the correct exit status without extra sentinels.

#### CMake integration
- **src/CMakeLists.txt**: Wired the three new utility libraries into the build via `add_subdirectory(utils/dsp)`, `add_subdirectory(utils/audio)`, and `add_subdirectory(utils/cli)`. The legacy flat `utils/*.{h,cpp}` and the existing aggregate `rpitx_utils` static library are left in place so current consumers continue to build unchanged; consumer migration to the new libraries will land in follow-up PRs.
- **CMakeLists.txt** (_root_): Updated the GCC 11 version-check comment to reference the new `src/utils/cli/cli_common.cpp` location of the floating-point `std::from_chars` usage.

#### Installation script
- **install.sh**: Added the new system dependencies required by the shared utility libraries — `libcli11-dev` (CLI parsing), `libsoxr-dev` (high-quality resampling), and `pkg-config` (locating `libsndfile` / `libsoxr` from CMake via `pkg_check_modules`).
