### PR TITLE
[Tests] Add unit tests for shared audio, CLI, and DSP utility libraries

### DIFF
--- a/.github/workflows/rpitx-ui-build.yml
+++ b/.github/workflows/rpitx-ui-build.yml
@@ -54,11 +54,11 @@ jobs:
             echo "::endgroup::"
 
             # ==============================================================
-            # 1. Install rpitx-ui
+            # 1. Install rpitx-ui with --enable-testing flag
             # ==============================================================
             echo "::group::Install rpitx-ui"
             sudo apt-get update && sudo apt-get install -y git
-            echo "n" | bash ./install.sh
+            echo "n" | bash ./install.sh --enable-testing
             echo "::endgroup::"
 
             # ==============================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 27.03.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,4 +88,16 @@ if(BUILD_OPTIONAL_TARGETS)
     include(cmake/ft8_lib-build.cmake)
 endif()
 
+# ----------------------------------------------------------
+# Test infrastructure
+# ----------------------------------------------------------
+# Tests are opt-in: production users running install.sh must not pay the
+# GoogleTest FetchContent cost, but contributors building locally enable the
+# suite via -DENABLE_TESTING=ON.
+option(ENABLE_TESTING "Build unit tests for the shared utility libraries" OFF)
+if(ENABLE_TESTING)
+    enable_testing()
+    include(cmake/googletest-build.cmake)
+endif()
+
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.26)
 project(rpitx-ui
-    VERSION 1.11
+    VERSION 1.12
     DESCRIPTION "RF transmitter for Raspberry Pi with improved UI functionality, built with CMake."
     LANGUAGES C CXX ASM
 )

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The [`install.sh`](./install.sh) script installs all system dependencies, builds
 Your support helps me continue developing open-source projects like [WSPR-beacon](https://github.com/IgrikXD/WSPR-beacon) and [Easy-SDR](https://github.com/IgrikXD/Easy-SDR), while also enabling the creation of new tools that benefit the community.
 
 ## Current development progress
-[![GitHub Actions: rpitx-ui build status][rpitx-ui-build-badge]](https://github.com/IgrikXD/rpitx-ui/actions/workflows/rpitx-ui-build.yml)&nbsp;![Package version](https://img.shields.io/badge/latest%20package%20version-1.11-blue.svg?longCache=true&style=for-the-badge)
+[![GitHub Actions: rpitx-ui build status][rpitx-ui-build-badge]](https://github.com/IgrikXD/rpitx-ui/actions/workflows/rpitx-ui-build.yml)&nbsp;![Package version](https://img.shields.io/badge/latest%20package%20version-1.12-blue.svg?longCache=true&style=for-the-badge)
 
 ## Installation process
 Clone the **rpitx-ui** repository:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To build only the core targets used directly by the `rpitx-ui` interface (_skipp
 ./install.sh --skip-optional
 ```
 
-To run the tests for the shared `audio` / `cli` / `dsp` utility libraries as part of the installation script execution, use the `--enable-testing` flag. A failing test aborts the installation process before any binaries are installed system-wide or the Raspberry Pi boot configuration is modified:
+To run the tests for the shared `audio` / `cli` / `dsp` utility libraries during installation, use the `--enable-testing` flag. A failing test aborts the installation before any binaries are installed system-wide or the Raspberry Pi boot configuration is modified:
 ```sh
 ./install.sh --enable-testing
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ To build only the core targets used directly by the `rpitx-ui` interface (_skipp
 ./install.sh --skip-optional
 ```
 
+To run the tests for the shared `audio` / `cli` / `dsp` utility libraries as part of the installation script execution, use the `--enable-testing` flag. A failing test aborts the installation process before any binaries are installed system-wide or the Raspberry Pi boot configuration is modified:
+```sh
+./install.sh --enable-testing
+```
+
 To add new files for transmission after installation, place them directly into `/usr/share/rpitx-ui`. You can override the default resource directory path by setting the `RPITX_RESOURCES_LOCATION` environment variable.
 
 ## Uninstallation process

--- a/cmake/googletest-build.cmake
+++ b/cmake/googletest-build.cmake
@@ -1,0 +1,31 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 05.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# GoogleTest / GoogleMock fetched as part of the test build
+# ----------------------------------------------------------
+# Pulled via FetchContent so the test suite is self-contained: CI / contributor
+# machines do not need a system-wide libgtest-dev.
+# ----------------------------------------------------------
+include(FetchContent)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.16.0
+    GIT_SHALLOW    TRUE
+    UPDATE_DISCONNECTED TRUE
+)
+
+# Suppress GoogleTest's own install() rules so `cmake --install` for rpitx-ui
+# does not leak gtest headers and archives into /usr.
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+# Build GoogleMock alongside GoogleTest.
+set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+include(GoogleTest)

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,13 @@ RESOURCE_INSTALL_DIR='/usr/share/rpitx-ui'
 COLOR_GREEN=$'\033[32m'
 COLOR_YELLOW=$'\033[33m'
 COLOR_BLUE=$'\033[34m'
+COLOR_RED=$'\033[31m'
 COLOR_RESET=$'\033[0m'
 
 # Status message helpers
 INFO="${COLOR_YELLOW}[INFO]${COLOR_RESET}"
 ACTION="${COLOR_BLUE}[ACTION REQUIRED]${COLOR_RESET}"
+ERROR="${COLOR_RED}[ERROR]${COLOR_RESET}"
 SEPARATOR='----------------------------------------------------'
 
 # Print a colored banner: print_banner <color_var> <message>
@@ -36,14 +38,18 @@ print_banner() {
 # Command-line options
 # ----------------------------------------------------------
 # Default: build all project targets and their dependencies
+# without building or running tests
 BUILD_OPTIONAL_TARGETS=true
+ENABLE_TESTING=false
 
 for arg in "$@"; do
   case "$arg" in
     --skip-optional) BUILD_OPTIONAL_TARGETS=false ;;
+    --enable-testing) ENABLE_TESTING=true ;;
     -h|--help)
-      echo "Usage: $0 [--skip-optional]"
-      echo "  --skip-optional  Build only targets used directly by easytest.sh and available through the UI"
+      echo "Usage: $0 [--skip-optional] [--enable-testing]"
+      echo "  --skip-optional   Build only targets used directly by easytest.sh and available through the UI"
+      echo "  --enable-testing  Build and execute tests during installation"
       exit 0
       ;;
     *) echo "Unknown option: $arg" >&2; exit 1 ;;
@@ -102,13 +108,36 @@ if [ "${BUILD_OPTIONAL_TARGETS}" = true ]; then
 else
   CMAKE_OPTIONAL=OFF
 fi
-cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_OPTIONAL_TARGETS="${CMAKE_OPTIONAL}"
+if [ "${ENABLE_TESTING}" = true ]; then
+  CMAKE_TESTING=ON
+else
+  CMAKE_TESTING=OFF
+fi
+cmake -B build \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DBUILD_OPTIONAL_TARGETS="${CMAKE_OPTIONAL}" \
+  -DENABLE_TESTING="${CMAKE_TESTING}"
 cmake --build build --parallel "$(nproc)"
+
+# rpitx-ui tests execution (if enabled)
+if [ "${ENABLE_TESTING}" = true ]; then
+  print_banner "$COLOR_YELLOW" "Starting test execution..."
+  # The `if ! ctest ...` form bypasses `set -e` for the ctest call so we can surface a tailored
+  # diagnostic instead of the bare "Errors while running CTest" line.
+  if ! ctest --test-dir build --output-on-failure --parallel "$(nproc)"; then
+    print_banner "$COLOR_RED" "Test execution failed - installation aborted!"
+    echo "${INFO} Review the ctest output above, fix the issues, and re-run rpitx-ui installation with the --enable-testing flag."
+    echo "${INFO} No files have been installed to /usr/bin or /usr/share/rpitx-ui."
+    exit 1
+  fi
+  print_banner "$COLOR_GREEN" "Test execution completed successfully!"
+fi
+
 sudo cmake --install build --prefix /usr
 print_banner "$COLOR_GREEN" "rpitx-ui-${PACKAGE_VERSION} built and installed successfully!"
 
 # Update /boot/config.txt or /boot/firmware/config.txt depending on Raspberry Pi OS version
-echo "${INFO} In order to run properly, rpitx-ui need to modify boot config."
+echo "${INFO} In order to run properly, rpitx-ui needs to modify boot config."
 echo "${INFO} Setting the GPU frequency to 250 MHz for stable rpitx-ui operation."
 if [ ! -f /boot/firmware/config.txt ]; then
   echo "${INFO} Raspberry Pi OS 11 or below detected, using /boot/config.txt"

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
 
 # rpitx-ui package version
-PACKAGE_VERSION='1.11'
+PACKAGE_VERSION='1.12'
 
 # Installed resource directory
 RESOURCE_INSTALL_DIR='/usr/share/rpitx-ui'

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,6 @@ COLOR_RESET=$'\033[0m'
 # Status message helpers
 INFO="${COLOR_YELLOW}[INFO]${COLOR_RESET}"
 ACTION="${COLOR_BLUE}[ACTION REQUIRED]${COLOR_RESET}"
-ERROR="${COLOR_RED}[ERROR]${COLOR_RESET}"
 SEPARATOR='----------------------------------------------------'
 
 # Print a colored banner: print_banner <color_var> <message>
@@ -38,8 +37,8 @@ print_banner() {
 # Command-line options
 # ----------------------------------------------------------
 # Default: build all project targets and their dependencies
-# without building or running tests
 BUILD_OPTIONAL_TARGETS=true
+# Default: do not build or run tests
 ENABLE_TESTING=false
 
 for arg in "$@"; do

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 28.04.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
@@ -7,9 +7,7 @@
 # ----------------------------------------------------------
 # Project-specific shared utility libraries
 # ----------------------------------------------------------
-add_subdirectory(utils/dsp)
-add_subdirectory(utils/audio)
-add_subdirectory(utils/cli)
+add_subdirectory(utils)
 
 # ----------------------------------------------------------
 # Define targets for each rpitx-ui component

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 15.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Project-specific shared utility libraries
+# ----------------------------------------------------------
+# Shared test utilities go first so the rpitx_common_test_utils INTERFACE
+# target is already declared when per-utility test subdirectories link
+# against it.
+if(ENABLE_TESTING)
+    add_subdirectory(tests)
+endif()
+
+add_subdirectory(dsp)
+add_subdirectory(audio)
+add_subdirectory(cli)

--- a/src/utils/audio/CMakeLists.txt
+++ b/src/utils/audio/CMakeLists.txt
@@ -26,3 +26,7 @@ add_library(rpitx_audio_utils STATIC
 )
 target_include_directories(rpitx_audio_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpitx_audio_utils PRIVATE PkgConfig::SNDFILE PkgConfig::SOXR)
+
+if(ENABLE_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/src/utils/audio/CMakeLists.txt
+++ b/src/utils/audio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 29.04.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.

--- a/src/utils/audio/tests/CMakeLists.txt
+++ b/src/utils/audio/tests/CMakeLists.txt
@@ -16,7 +16,6 @@ add_executable(rpitx_audio_utils_tests
     test_audio_rate_converter.cpp
     test_libsndfile_audio_source.cpp
     test_soxr_resampler.cpp
-    test_validate_helpers.cpp
 )
 
 target_link_libraries(rpitx_audio_utils_tests

--- a/src/utils/audio/tests/CMakeLists.txt
+++ b/src/utils/audio/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 05.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Unit tests for the shared audio utility library
+# ----------------------------------------------------------
+# libsndfile and libsoxr are PRIVATE deps of rpitx_audio_utils, so the test
+# target re-imports libsndfile (PkgConfig::SNDFILE was declared by the parent
+# directory and is visible through inheritance) for tests that drive the
+# libsndfile factory directly with WAV files written from the test harness.
+add_executable(rpitx_audio_utils_tests
+    test_audio_pipeline.cpp
+    test_audio_rate_converter.cpp
+    test_libsndfile_audio_source.cpp
+    test_soxr_resampler.cpp
+    test_validate_helpers.cpp
+)
+
+target_link_libraries(rpitx_audio_utils_tests
+    PRIVATE
+        rpitx_audio_utils
+        PkgConfig::SNDFILE
+        GTest::gtest
+        GTest::gmock
+        GTest::gtest_main
+)
+
+gtest_discover_tests(rpitx_audio_utils_tests
+    PROPERTIES LABELS "unit;audio"
+)

--- a/src/utils/audio/tests/CMakeLists.txt
+++ b/src/utils/audio/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 05.05.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
@@ -21,6 +21,7 @@ add_executable(rpitx_audio_utils_tests
 target_link_libraries(rpitx_audio_utils_tests
     PRIVATE
         rpitx_audio_utils
+        rpitx_common_test_utils
         PkgConfig::SNDFILE
         GTest::gtest
         GTest::gmock

--- a/src/utils/audio/tests/fake_audio_source.h
+++ b/src/utils/audio/tests/fake_audio_source.h
@@ -68,9 +68,8 @@ public:
         // test that drives the AudioSource contract directly instead of
         // through AudioPipeline.
         if (channels == 0 || dst.empty() || dst.size() % channels != 0) {
-            throw std::invalid_argument{
-                "FakeAudioSource::read: dst must be a non-empty whole number of frames (size " +
-                std::to_string(dst.size()) + ", channels " + std::to_string(channels) + ")"};
+            throw std::invalid_argument{"FakeAudioSource::read: dst must be a non-empty whole number of frames (size " +
+                                        std::to_string(dst.size()) + ", channels " + std::to_string(channels) + ")"};
         }
         if (error_) {
             return 0;

--- a/src/utils/audio/tests/fake_audio_source.h
+++ b/src/utils/audio/tests/fake_audio_source.h
@@ -1,0 +1,94 @@
+/**
+ * @file fake_audio_source.h
+ * @brief Programmable in-memory AudioSource for unit-test fixtures.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 15.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "audio_source.h"
+
+/**
+ * @brief Lightweight programmable AudioSource for the AudioPipeline tests.
+ *
+ * Backed by an in-memory float vector. Tests configure the channel count, sample rate, and
+ * seekability up-front, then drive the pipeline through the public read() / rewind() path
+ * without spinning up a libsndfile-backed file source. setError() drives the pipeline's
+ * source-error branch.
+ */
+class FakeAudioSource final : public AudioSource {
+public:
+    FakeAudioSource(AudioFormat format, std::vector<float> samples, bool seekable = true)
+        : format_{format}, samples_{std::move(samples)}, seekable_{seekable} {
+    }
+
+    /**
+     * @brief Construct a no-data source (read() returns 0 immediately).
+     *
+     * Useful when only the format / seekable bits are exercised, e.g. in validateLoopSupport
+     * tests where the pipeline never actually reads the source.
+     */
+    FakeAudioSource(AudioFormat format, bool seekable) : format_{format}, seekable_{seekable} {
+    }
+
+    /**
+     * @brief Set the sticky error flag. Once true, read() returns 0 and error() returns true
+     *        on every subsequent call, matching the AudioSource contract.
+     */
+    void setError(bool flag) {
+        error_ = flag;
+    }
+
+    [[nodiscard]] AudioFormat format() const override {
+        return format_;
+    }
+
+    [[nodiscard]] std::string_view description() const override {
+        return "fake";
+    }
+
+    [[nodiscard]] std::size_t read(std::span<float> dst) override {
+        if (error_) {
+            return 0;
+        }
+        const std::size_t available{samples_.size() - readPos_};
+        const std::size_t take{std::min(available, dst.size())};
+        std::copy_n(samples_.data() + readPos_, take, dst.begin());
+        readPos_ += take;
+        return take;
+    }
+
+    [[nodiscard]] bool rewind() override {
+        if (seekable_ == false) {
+            return false;
+        }
+        readPos_ = 0;
+        return true;
+    }
+
+    [[nodiscard]] bool seekable() const override {
+        return seekable_;
+    }
+    [[nodiscard]] bool error() const override {
+        return error_;
+    }
+
+private:
+    AudioFormat format_;
+    std::vector<float> samples_;
+    bool seekable_{true};
+    bool error_{false};
+    std::size_t readPos_{0};
+};

--- a/src/utils/audio/tests/fake_audio_source.h
+++ b/src/utils/audio/tests/fake_audio_source.h
@@ -23,34 +23,20 @@
 #include "audio_source.h"
 
 /**
- * @brief Lightweight programmable AudioSource for the AudioPipeline tests.
+ * @brief In-memory sample-buffer AudioSource for tests that need real samples flowing through
+ *        the AudioPipeline data path.
  *
- * Backed by an in-memory float vector. Tests configure the channel count, sample rate, and
- * seekability up-front, then drive the pipeline through the public read() / rewind() path
- * without spinning up a libsndfile-backed file source. setError() drives the pipeline's
- * source-error branch.
+ * Narrowly scoped to the data-flow side of the test suite: passthrough bit-exactness, downmix
+ * averaging, channel-preserve propagation, loop replay continuity, and frame-count / resample
+ * checks. Every behaviour-side test (empty source, sticky error, partial-frame return, rewind
+ * interaction, ctor-touches-nothing-else) uses MockAudioSource instead, where each per-method
+ * return value is a literal in the test body rather than a slice of state-machine logic in
+ * this header - which keeps the bug surface for test infrastructure at zero.
  */
 class FakeAudioSource final : public AudioSource {
 public:
     FakeAudioSource(AudioFormat format, std::vector<float> samples, bool seekable)
         : format_{format}, samples_{std::move(samples)}, seekable_{seekable} {
-    }
-
-    /**
-     * @brief Construct a no-data source (read() returns 0 immediately).
-     *
-     * Useful when only the format / seekable bits are exercised, e.g. in validateLoopSupport
-     * tests where the pipeline never actually reads the source.
-     */
-    FakeAudioSource(AudioFormat format, bool seekable) : format_{format}, seekable_{seekable} {
-    }
-
-    /**
-     * @brief Set the sticky error flag. Once true, read() returns 0 and error() returns true
-     *        on every subsequent call, matching the AudioSource contract.
-     */
-    void setError(bool flag) {
-        error_ = flag;
     }
 
     [[nodiscard]] AudioFormat format() const override {
@@ -64,15 +50,11 @@ public:
     [[nodiscard]] std::size_t read(std::span<float> dst) override {
         const auto channels{static_cast<std::size_t>(format_.channels)};
         // Mirror the throw-on-misalignment contract enforced by
-        // LibsndfileAudioSource::read so the fake stays substitutable in any
-        // test that drives the AudioSource contract directly instead of
-        // through AudioPipeline.
+        // LibsndfileAudioSource::read so a misuse of the fake by a future test surfaces as a
+        // loud programmer error rather than as a confusing short read.
         if (channels == 0 || dst.empty() || dst.size() % channels != 0) {
             throw std::invalid_argument{"FakeAudioSource::read: dst must be a non-empty whole number of frames (size " +
                                         std::to_string(dst.size()) + ", channels " + std::to_string(channels) + ")"};
-        }
-        if (error_) {
-            return 0;
         }
         const std::size_t available{samples_.size() - readPos_};
         const std::size_t take{std::min(available, dst.size())};
@@ -93,13 +75,12 @@ public:
         return seekable_;
     }
     [[nodiscard]] bool error() const override {
-        return error_;
+        return false;
     }
 
 private:
     AudioFormat format_;
     std::vector<float> samples_;
     bool seekable_;
-    bool error_{false};
     std::size_t readPos_{0};
 };

--- a/src/utils/audio/tests/fake_audio_source.h
+++ b/src/utils/audio/tests/fake_audio_source.h
@@ -14,6 +14,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <span>
+#include <stdexcept>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -30,7 +32,7 @@
  */
 class FakeAudioSource final : public AudioSource {
 public:
-    FakeAudioSource(AudioFormat format, std::vector<float> samples, bool seekable = true)
+    FakeAudioSource(AudioFormat format, std::vector<float> samples, bool seekable)
         : format_{format}, samples_{std::move(samples)}, seekable_{seekable} {
     }
 
@@ -60,6 +62,16 @@ public:
     }
 
     [[nodiscard]] std::size_t read(std::span<float> dst) override {
+        const auto channels{static_cast<std::size_t>(format_.channels)};
+        // Mirror the throw-on-misalignment contract enforced by
+        // LibsndfileAudioSource::read so the fake stays substitutable in any
+        // test that drives the AudioSource contract directly instead of
+        // through AudioPipeline.
+        if (channels == 0 || dst.empty() || dst.size() % channels != 0) {
+            throw std::invalid_argument{
+                "FakeAudioSource::read: dst must be a non-empty whole number of frames (size " +
+                std::to_string(dst.size()) + ", channels " + std::to_string(channels) + ")"};
+        }
         if (error_) {
             return 0;
         }
@@ -88,7 +100,7 @@ public:
 private:
     AudioFormat format_;
     std::vector<float> samples_;
-    bool seekable_{true};
+    bool seekable_;
     bool error_{false};
     std::size_t readPos_{0};
 };

--- a/src/utils/audio/tests/mock_audio_source.h
+++ b/src/utils/audio/tests/mock_audio_source.h
@@ -1,0 +1,41 @@
+/**
+ * @file mock_audio_source.h
+ * @brief GoogleMock implementation of AudioSource for interaction-based unit tests.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 15.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <cstddef>
+#include <span>
+#include <string_view>
+
+#include "audio_source.h"
+
+/**
+ * @brief GoogleMock-based AudioSource used by the AudioPipeline interaction-tests.
+ *
+ * Complements FakeAudioSource: the fake supplies a real interleaved sample buffer for
+ * tests that verify arithmetic (passthrough copy, downmix average, channel-preserve
+ * propagation), while the mock targets the behavioural contracts that the fake cannot
+ * express - per-call return sequences (e.g. positive read followed by error()=true),
+ * call-count expectations on rewind() under loop mode, partial-frame returns that
+ * trigger the SUT's std::logic_error branch, and StrictMock-driven assertions about
+ * which source methods the ctor is allowed to touch.
+ */
+class MockAudioSource : public AudioSource {
+public:
+    MOCK_METHOD(AudioFormat, format, (), (const, override));
+    MOCK_METHOD(std::string_view, description, (), (const, override));
+    MOCK_METHOD(std::size_t, read, (std::span<float> dst), (override));
+    MOCK_METHOD(bool, rewind, (), (override));
+    MOCK_METHOD(bool, seekable, (), (const, override));
+    MOCK_METHOD(bool, error, (), (const, override));
+};

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -769,7 +769,8 @@ TEST(AudioPipelineReadTest, LoopModeInvokesRewindWhenSourceDrains) {
  *
  * Rewinding an empty source produces another empty read on every iteration - the SUT must
  * detect "no progress after rewind" and convert it to End rather than spinning forever
- * pulling zero samples through an unending sequence of rewinds.
+ * pulling zero samples through an unending sequence of rewinds. The AtMost ceilings turn
+ * a livelock regression into a loud EXPECT_CALL failure instead of a ctest timeout.
  */
 TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
     ::testing::NiceMock<MockAudioSource> source;
@@ -779,8 +780,13 @@ TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
             .sampleRate = kBroadcastRateHz,
         }));
     ON_CALL(source, seekable()).WillByDefault(::testing::Return(true));
-    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(0));
-    ON_CALL(source, rewind()).WillByDefault(::testing::Return(true));
+    constexpr int kLivelockCallCeiling{8};
+    EXPECT_CALL(source, read(::testing::_))
+        .Times(::testing::AtMost(kLivelockCallCeiling))
+        .WillRepeatedly(::testing::Return(0));
+    EXPECT_CALL(source, rewind())
+        .Times(::testing::AtMost(kLivelockCallCeiling))
+        .WillRepeatedly(::testing::Return(true));
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = true,

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -283,12 +283,14 @@ class AudioPipelineCtorTest
     : public CapturedStreamsMixin<::testing::TestWithParam<AudioPipelineCtorRejectionTestCase>> {};
 
 /**
- * @brief Ctor throws std::invalid_argument for any rejected config combination.
+ * @brief Ctor throws std::invalid_argument for any rejected config and emits no stderr diagnostic.
  *
  * The exception type is uniform across the two rejection branches (channel-count check in
  * AudioPipeline::AudioPipeline; targetOutputFrames check in the per-channel
  * AudioRateConverter ctor), so the test does not need to differentiate which branch fired -
- * surfacing std::invalid_argument from any rejected config is the public contract.
+ * surfacing std::invalid_argument from any rejected config is the public contract. The
+ * stderr-empty check pins the silence half: a future ctor that printed a diagnostic before
+ * throwing would slip past a throw-only assertion.
  */
 TEST_P(AudioPipelineCtorTest, ThrowsInvalidArgument) {
     const auto& testCase{GetParam()};
@@ -306,6 +308,7 @@ TEST_P(AudioPipelineCtorTest, ThrowsInvalidArgument) {
                                    .channelMode        = AudioChannelMode::Mono,
                                }),
                  std::invalid_argument);
+    EXPECT_TRUE(capturedStderr().empty());
 }
 
 INSTANTIATE_TEST_SUITE_P(RejectedConfig, AudioPipelineCtorTest,
@@ -358,12 +361,14 @@ class AudioPipelineOutputGeometryTest : public CapturedStreamsMixin<::testing::T
 };
 
 /**
- * @brief Output channel count, frame count, and samples-per-block follow channelMode and targetOutputFrames.
+ * @brief Output dimensions follow channelMode and targetOutputFrames, and construction stays silent on stderr.
  *
  * Mono mode collapses any source-channel count to 1; Preserve mode passes the source-channel
  * count through. outputSamplesPerBlock() multiplies frames by the resulting channel count -
  * checking that derived value alongside the two primary getters catches a regression in
- * either factor or the multiplication itself.
+ * either factor or the multiplication itself. The stderr-empty check pins the
+ * construction-path silence: a ctor or getter that leaked a warning would slip past the
+ * value checks.
  */
 TEST_P(AudioPipelineOutputGeometryTest, ReportsExpectedOutputDimensions) {
     const auto& testCase{GetParam()};
@@ -383,6 +388,7 @@ TEST_P(AudioPipelineOutputGeometryTest, ReportsExpectedOutputDimensions) {
     EXPECT_EQ(pipeline.outputChannels(), testCase.expectedOutputChannels);
     EXPECT_EQ(pipeline.outputFrames(), testCase.targetOutputFrames);
     EXPECT_EQ(pipeline.outputSamplesPerBlock(), testCase.expectedOutputSamplesPerBlock);
+    EXPECT_TRUE(capturedStderr().empty());
 }
 
 INSTANTIATE_TEST_SUITE_P(ChannelModeMatrix, AudioPipelineOutputGeometryTest,

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -429,9 +429,9 @@ TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
  * Equal source/target rate with a mono source collapses the data path to four std::copy
  * hops (libsoxr is not even instantiated) - no arithmetic touches the sample values, so
  * gtest's 4-ULP float precision is the right strictness; any larger drift signals a
- * non-passthrough code path leaking into the equal-rate mono case. kFrames is a multiple
- * of targetOutputFrames, so the inner loop's reference-size guard is defensive only and
- * never short-circuits at the chosen values.
+ * non-passthrough code path leaking into the equal-rate mono case. kSourceFrames is a
+ * multiple of targetOutputFrames so the inner loop indexes referenceSamples in-bounds
+ * through every Ok block.
  */
 TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
     constexpr std::size_t kSourceFrames{4096};
@@ -462,8 +462,7 @@ TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
             break;
         }
         ASSERT_EQ(status, AudioPipelineStatus::Ok);
-        for (std::size_t sampleIdx{0}; sampleIdx < outputBlock.size() && comparedSampleCount < referenceSamples.size();
-             ++sampleIdx, ++comparedSampleCount) {
+        for (std::size_t sampleIdx{0}; sampleIdx < outputBlock.size(); ++sampleIdx, ++comparedSampleCount) {
             EXPECT_FLOAT_EQ(outputBlock[sampleIdx], referenceSamples[comparedSampleCount])
                 << "Mismatch at sample " << comparedSampleCount;
         }

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -322,11 +322,8 @@ INSTANTIATE_TEST_SUITE_P(RejectedConfig, AudioPipelineCtorTest,
  *        seekable() / description().
  *
  * Pins the construction-path interaction contract: AudioPipeline must materialize its geometry
- * from the format snapshot alone, deferring every data-path interaction with the source until
- * the first read() call. StrictMock fails the test if the ctor calls any unprogrammed method,
- * so a regression that probed seekable() up-front (e.g. moving validateLoopSupport into the
- * ctor) or pre-pulled samples for warmup would surface as a strict-mock violation rather than
- * passing silently.
+ * from the format snapshot alone. A regression that probed seekable() up-front (e.g. moving
+ * validateLoopSupport into the ctor) or pre-pulled samples for warmup would trip the StrictMock.
  */
 TEST(AudioPipelineCtorInteractionTest, CtorTouchesOnlyFormatOnce) {
     ::testing::StrictMock<MockAudioSource> source;
@@ -464,12 +461,9 @@ TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
  *
  * AudioBlockReader treats a non-multiple-of-channels positive return as a backend invariant
  * violation rather than a soft EOF, surfacing it as std::logic_error so the failure cannot be
- * misread as a clean end-of-stream. Driving the contract via the mock is the only way to
- * exercise it - LibsndfileAudioSource cannot produce such a return (sf_readf_float reads in
- * whole frames by API), and FakeAudioSource does not produce it in current usage either:
- * every caller initialises its samples buffer as a whole number of frames, so each
- * min(remaining, dst.size()) take stays aligned. Stereo source with a return of 3 (3 % 2 != 0)
- * is the smallest input that trips the check.
+ * misread as a clean end-of-stream. The mock is the only way to exercise this path - no real
+ * source produces a misaligned return in practice. Stereo with a return of 3 (3 % 2 != 0) is
+ * the smallest input that trips the check.
  */
 TEST(AudioPipelineReadTest, ThrowsLogicErrorOnPartialFrameFromSource) {
     ::testing::NiceMock<MockAudioSource> source;
@@ -620,10 +614,9 @@ TEST(AudioPipelineReadTest, StereoPreserveModePropagatesIndependentChannels) {
 /**
  * @brief read() returns Error when the source's first call returns zero samples with error()=true.
  *
- * The mock surfaces error()=true on the same call that returns 0 samples, so the pipeline
- * reader hits the error-during-zero-read path and reports Error rather than End -
- * distinguishing a fatal I/O failure from a clean EOF on the same zero-sample return. The
- * orthogonal positive-then-error path is covered by ReportsErrorWhenSourceErrorsAfterPositiveRead.
+ * Distinguishes a fatal I/O failure from a clean EOF on the same zero-sample return - the
+ * pipeline must report Error, not End. The orthogonal positive-then-error branch is covered
+ * by ReportsErrorWhenSourceErrorsAfterPositiveRead.
  */
 TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorFlagIsSet) {
     ::testing::NiceMock<MockAudioSource> source;
@@ -648,15 +641,12 @@ TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorFlagIsSet) {
 }
 
 /**
- * @brief read() returns Error when the source surfaces error() = true on the same call that
+ * @brief read() returns Error when the source surfaces error()=true on the same call that
  *        returned a positive partial sample count.
  *
- * AudioSource's documented contract (audio_source.h) permits a backend to report a fatal failure
- * after a positive short read - the post-positive-read error check in AudioBlockReader is the
- * SUT branch handling that case. ReportsErrorWhenSourceErrorFlagIsSet covers the orthogonal
- * "error visible on the first zero-sample return" branch; this test covers the positive-then-error
- * variant. Returning kPositiveSamplesRead samples then reporting error()=true forces the SUT
- * down that path and pins down its Error verdict.
+ * AudioSource's contract (audio_source.h) permits a backend to report a fatal failure after
+ * a positive short read. ReportsErrorWhenSourceErrorFlagIsSet covers the orthogonal
+ * zero-sample-then-error branch; this one covers the positive-then-error variant.
  */
 TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorsAfterPositiveRead) {
     ::testing::NiceMock<MockAudioSource> source;
@@ -744,13 +734,10 @@ TEST(AudioPipelineReadTest, LoopModeReplaysContent) {
 /**
  * @brief Loop mode invokes source.rewind() at least once when the source drains mid-block.
  *
- * LoopModeReplaysContent already pins the state-side outcome (read() keeps returning Ok across
- * iterations); this test pins the interaction-side contract that the SUT actually drives
- * rewind() on the source rather than synthesising replayed samples internally. Mock returns a
- * short initial chunk then perpetual EOF so the AudioBlockReader is forced into the rewind
- * branch within the first pipeline.read() call. The test deliberately does not assert on the
- * returned status - the rewind expectation is the verifiable contract here, and pinning the
- * status would duplicate LoopModeReplaysContent on the state-side axis.
+ * LoopModeReplaysContent already pins the state-side outcome (Ok across iterations); this test
+ * pins the interaction-side: the SUT must actually drive rewind() on the source. The test
+ * deliberately does not assert on the returned status - the rewind expectation is the
+ * verifiable contract here, and pinning the status would duplicate LoopModeReplaysContent.
  */
 TEST(AudioPipelineReadTest, LoopModeInvokesRewindWhenSourceDrains) {
     ::testing::NiceMock<MockAudioSource> source;
@@ -810,11 +797,9 @@ TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
 /**
  * @brief Loop mode reports Error when source.rewind() fails on the boundary.
  *
- * Distinct from LoopModeReportsEndOnEmptySource, which exercises the rewind-then-empty path
- * with rewind()=true. Here rewind() returns false on the first EOF, modelling a backend whose
- * seekable() advertisement turned out to be a lie at the moment the seek was actually issued -
- * the SUT must surface this as Error rather than swallowing the seek failure and falling
- * through to End.
+ * Distinct from LoopModeReportsEndOnEmptySource (rewind()=true followed by empty source).
+ * Here rewind() returns false on the first EOF - the SUT must surface this as Error rather
+ * than swallow the failure and fall through to End.
  */
 TEST(AudioPipelineReadTest, ReportsErrorWhenLoopRewindFails) {
     ::testing::NiceMock<MockAudioSource> source;

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -297,17 +297,14 @@ TEST_P(AudioPipelineCtorTest, ThrowsInvalidArgument) {
                            },
                            true};
 
-    EXPECT_THROW(
-        {
-            [[maybe_unused]] AudioPipeline pipeline(source,
-                                                    AudioPipelineConfig{
-                                                        .loop               = false,
-                                                        .targetSampleRate   = kBroadcastRateHz,
-                                                        .targetOutputFrames = testCase.targetOutputFrames,
-                                                        .channelMode        = AudioChannelMode::Mono,
-                                                    });
-        },
-        std::invalid_argument);
+    EXPECT_THROW(AudioPipeline(source,
+                               AudioPipelineConfig{
+                                   .loop               = false,
+                                   .targetSampleRate   = kBroadcastRateHz,
+                                   .targetOutputFrames = testCase.targetOutputFrames,
+                                   .channelMode        = AudioChannelMode::Mono,
+                               }),
+                 std::invalid_argument);
 }
 
 INSTANTIATE_TEST_SUITE_P(RejectedConfig, AudioPipelineCtorTest,

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -424,15 +424,14 @@ TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
 }
 
 /**
- * @brief Mono passthrough reproduces the input sample-by-sample within a 1e-5 tolerance.
+ * @brief Mono passthrough reproduces the input sample-by-sample bit-exactly.
  *
- * Equal source/target rate plus mono-mode on a mono source minimizes per-sample arithmetic:
- * the downmix collapses to a single-channel copy and AudioRateConverter takes its
- * passthrough fast path (libsoxr is not even instantiated), so any deviation beyond 1e-5
- * between the source and the output points to a regression in the pass-through path.
- * kFrames is a multiple of targetOutputFrames, so the source is consumed in whole blocks
- * with no zero-pad tail; the reference-size guard on the inner loop is defensive against
- * future tweaks to either constant and never short-circuits at the chosen values.
+ * Equal source/target rate with a mono source collapses the data path to four std::copy
+ * hops (libsoxr is not even instantiated) - no arithmetic touches the sample values, so
+ * gtest's 4-ULP float precision is the right strictness; any larger drift signals a
+ * non-passthrough code path leaking into the equal-rate mono case. kFrames is a multiple
+ * of targetOutputFrames, so the inner loop's reference-size guard is defensive only and
+ * never short-circuits at the chosen values.
  */
 TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
     constexpr std::size_t kFrames{4096};
@@ -465,7 +464,7 @@ TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
         ASSERT_EQ(status, AudioPipelineStatus::Ok);
         for (std::size_t sampleIdx{0}; sampleIdx < outputBlock.size() && comparedSampleCount < referenceSamples.size();
              ++sampleIdx, ++comparedSampleCount) {
-            EXPECT_NEAR(outputBlock[sampleIdx], referenceSamples[comparedSampleCount], 1e-5F)
+            EXPECT_FLOAT_EQ(outputBlock[sampleIdx], referenceSamples[comparedSampleCount])
                 << "Mismatch at sample " << comparedSampleCount;
         }
     }

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -434,10 +434,10 @@ TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
  * never short-circuits at the chosen values.
  */
 TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
-    constexpr std::size_t kFrames{4096};
-    std::vector<float> samples(kFrames);
-    for (std::size_t frame{0}; frame < kFrames; ++frame) {
-        samples[frame] = static_cast<float>(frame) / static_cast<float>(kFrames) * 0.5F;
+    constexpr std::size_t kSourceFrames{4096};
+    std::vector<float> samples(kSourceFrames);
+    for (std::size_t frame{0}; frame < kSourceFrames; ++frame) {
+        samples[frame] = static_cast<float>(frame) / static_cast<float>(kSourceFrames) * 0.5F;
     }
     const auto referenceSamples{samples};
     FakeAudioSource source{AudioFormat{
@@ -482,9 +482,9 @@ TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
  * sign-flip regressions slip through silently.
  */
 TEST(AudioPipelineReadTest, StereoMonoModeAveragesChannels) {
-    constexpr std::size_t kFrames{2048};
-    std::vector<float> samples(kFrames * 2);
-    for (std::size_t frame{0}; frame < kFrames; ++frame) {
+    constexpr std::size_t kSourceFrames{2048};
+    std::vector<float> samples(kSourceFrames * 2);
+    for (std::size_t frame{0}; frame < kSourceFrames; ++frame) {
         samples[frame * 2 + 0] = 1.0F;
         samples[frame * 2 + 1] = 0.5F;
     }
@@ -514,9 +514,9 @@ TEST(AudioPipelineReadTest, StereoMonoModeAveragesChannels) {
  * would average the two to -0.125 and trip the EXPECT_NEAR on both interleaved slots.
  */
 TEST(AudioPipelineReadTest, StereoPreserveModePropagatesIndependentChannels) {
-    constexpr std::size_t kFrames{2048};
-    std::vector<float> samples(kFrames * 2);
-    for (std::size_t frame{0}; frame < kFrames; ++frame) {
+    constexpr std::size_t kSourceFrames{2048};
+    std::vector<float> samples(kSourceFrames * 2);
+    for (std::size_t frame{0}; frame < kSourceFrames; ++frame) {
         samples[frame * 2 + 0] = 0.25F;
         samples[frame * 2 + 1] = -0.5F;
     }

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -9,6 +9,7 @@
  * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cstddef>
@@ -23,6 +24,7 @@
 #include "audio_pipeline.h"
 #include "captured_streams_mixin.h"
 #include "fake_audio_source.h"
+#include "mock_audio_source.h"
 
 namespace {
     /**
@@ -226,11 +228,8 @@ class ValidateLoopSupportTest : public CapturedStreamsMixin<::testing::TestWithP
  */
 TEST_P(ValidateLoopSupportTest, MatchesExpectedOutcome) {
     const auto& testCase{GetParam()};
-    FakeAudioSource source{AudioFormat{
-                               .channels   = 1,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           testCase.seekable};
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, seekable()).WillByDefault(::testing::Return(testCase.seekable));
 
     const bool accepted{validateLoopSupport(source, testCase.loopRequested)};
 
@@ -294,11 +293,12 @@ class AudioPipelineCtorTest
  */
 TEST_P(AudioPipelineCtorTest, ThrowsInvalidArgument) {
     const auto& testCase{GetParam()};
-    FakeAudioSource source{AudioFormat{
-                               .channels   = testCase.sourceChannels,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           true};
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = testCase.sourceChannels,
+            .sampleRate = kBroadcastRateHz,
+        }));
 
     EXPECT_THROW(AudioPipeline(source,
                                AudioPipelineConfig{
@@ -316,6 +316,34 @@ INSTANTIATE_TEST_SUITE_P(RejectedConfig, AudioPipelineCtorTest,
                          [](const ::testing::TestParamInfo<AudioPipelineCtorRejectionTestCase>& info) {
                              return std::string{info.param.name};
                          });
+
+/**
+ * @brief Ctor pulls source.format() exactly once and never touches read() / rewind() / error() /
+ *        seekable() / description().
+ *
+ * Pins the construction-path interaction contract: AudioPipeline must materialize its geometry
+ * from the format snapshot alone, deferring every data-path interaction with the source until
+ * the first read() call. StrictMock fails the test if the ctor calls any unprogrammed method,
+ * so a regression that probed seekable() up-front (e.g. moving validateLoopSupport into the
+ * ctor) or pre-pulled samples for warmup would surface as a strict-mock violation rather than
+ * passing silently.
+ */
+TEST(AudioPipelineCtorInteractionTest, CtorTouchesOnlyFormatOnce) {
+    ::testing::StrictMock<MockAudioSource> source;
+    EXPECT_CALL(source, format())
+        .WillOnce(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+}
 
 namespace {
     struct OutputGeometryTestCase {
@@ -372,11 +400,12 @@ class AudioPipelineOutputGeometryTest : public CapturedStreamsMixin<::testing::T
  */
 TEST_P(AudioPipelineOutputGeometryTest, ReportsExpectedOutputDimensions) {
     const auto& testCase{GetParam()};
-    FakeAudioSource source{AudioFormat{
-                               .channels   = testCase.sourceChannels,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           true};
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = testCase.sourceChannels,
+            .sampleRate = kBroadcastRateHz,
+        }));
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = false,
@@ -406,11 +435,12 @@ INSTANTIATE_TEST_SUITE_P(ChannelModeMatrix, AudioPipelineOutputGeometryTest,
  * against expected 1024) would let slip through.
  */
 TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
-    FakeAudioSource source{AudioFormat{
-                               .channels   = 1,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           true};
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = false,
@@ -427,6 +457,39 @@ TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
     EXPECT_THROW(
         { [[maybe_unused]] const AudioPipelineStatus status{pipeline.read(oversizedOutputBlock)}; },
         std::invalid_argument);
+}
+
+/**
+ * @brief read() throws std::logic_error when the source returns a partial-frame sample count.
+ *
+ * AudioBlockReader treats a non-multiple-of-channels positive return as a backend invariant
+ * violation rather than a soft EOF, surfacing it as std::logic_error so the failure cannot be
+ * misread as a clean end-of-stream. Driving the contract via the mock is the only way to
+ * exercise it - LibsndfileAudioSource cannot produce such a return (sf_readf_float reads in
+ * whole frames by API), and FakeAudioSource does not produce it in current usage either:
+ * every caller initialises its samples buffer as a whole number of frames, so each
+ * min(remaining, dst.size()) take stays aligned. Stereo source with a return of 3 (3 % 2 != 0)
+ * is the smallest input that trips the check.
+ */
+TEST(AudioPipelineReadTest, ThrowsLogicErrorOnPartialFrameFromSource) {
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 2,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    constexpr std::size_t kPartialFrameSamplesRead{3};
+    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(kPartialFrameSamplesRead));
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Preserve,
+                           });
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+
+    EXPECT_THROW({ [[maybe_unused]] const AudioPipelineStatus status{pipeline.read(outputBlock)}; }, std::logic_error);
 }
 
 /**
@@ -555,19 +618,56 @@ TEST(AudioPipelineReadTest, StereoPreserveModePropagatesIndependentChannels) {
 }
 
 /**
- * @brief read() returns Error when the source already has its sticky error flag raised on the first read.
+ * @brief read() returns Error when the source's first call returns zero samples with error()=true.
  *
- * FakeAudioSource publishes error()=true at the same call that returns 0 samples, so the
- * pipeline reader hits the error-during-zero-read path and reports Error rather than End -
- * distinguishing a fatal I/O failure from a clean EOF on the same zero-sample return.
+ * The mock surfaces error()=true on the same call that returns 0 samples, so the pipeline
+ * reader hits the error-during-zero-read path and reports Error rather than End -
+ * distinguishing a fatal I/O failure from a clean EOF on the same zero-sample return. The
+ * orthogonal positive-then-error path is covered by ReportsErrorWhenSourceErrorsAfterPositiveRead.
  */
 TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorFlagIsSet) {
-    FakeAudioSource source{AudioFormat{
-                               .channels   = 1,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           true};
-    source.setError(true);
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(0));
+    ON_CALL(source, error()).WillByDefault(::testing::Return(true));
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+
+    EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::Error);
+}
+
+/**
+ * @brief read() returns Error when the source surfaces error() = true on the same call that
+ *        returned a positive partial sample count.
+ *
+ * AudioSource's documented contract (audio_source.h) permits a backend to report a fatal failure
+ * after a positive short read - the post-positive-read error check in AudioBlockReader is the
+ * SUT branch handling that case. ReportsErrorWhenSourceErrorFlagIsSet covers the orthogonal
+ * "error visible on the first zero-sample return" branch; this test covers the positive-then-error
+ * variant. Returning kPositiveSamplesRead samples then reporting error()=true forces the SUT
+ * down that path and pins down its Error verdict.
+ */
+TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorsAfterPositiveRead) {
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    constexpr std::size_t kPositiveSamplesRead{64};
+    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(kPositiveSamplesRead));
+    ON_CALL(source, error()).WillByDefault(::testing::Return(true));
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = false,
@@ -589,11 +689,13 @@ TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorFlagIsSet) {
  * stays set and subsequent reads continue returning End instead of attempting to restart.
  */
 TEST(AudioPipelineReadTest, NonLoopOnEmptySourceReturnsEndAndStays) {
-    FakeAudioSource source{AudioFormat{
-                               .channels   = 1,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           true};
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(0));
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = false,
@@ -640,6 +742,42 @@ TEST(AudioPipelineReadTest, LoopModeReplaysContent) {
 }
 
 /**
+ * @brief Loop mode invokes source.rewind() at least once when the source drains mid-block.
+ *
+ * LoopModeReplaysContent already pins the state-side outcome (read() keeps returning Ok across
+ * iterations); this test pins the interaction-side contract that the SUT actually drives
+ * rewind() on the source rather than synthesising replayed samples internally. Mock returns a
+ * short initial chunk then perpetual EOF so the AudioBlockReader is forced into the rewind
+ * branch within the first pipeline.read() call. The test deliberately does not assert on the
+ * returned status - the rewind expectation is the verifiable contract here, and pinning the
+ * status would duplicate LoopModeReplaysContent on the state-side axis.
+ */
+TEST(AudioPipelineReadTest, LoopModeInvokesRewindWhenSourceDrains) {
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    ON_CALL(source, seekable()).WillByDefault(::testing::Return(true));
+    constexpr std::size_t kInitialPartialReadSamples{100};
+    EXPECT_CALL(source, read(::testing::_))
+        .WillOnce(::testing::Return(kInitialPartialReadSamples))
+        .WillRepeatedly(::testing::Return(0));
+    EXPECT_CALL(source, rewind()).Times(::testing::AtLeast(1)).WillRepeatedly(::testing::Return(true));
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = true,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+    [[maybe_unused]] const auto status{pipeline.read(outputBlock)};
+}
+
+/**
  * @brief Loop mode on an empty seekable source reports End instead of livelocking on empty replays.
  *
  * Rewinding an empty source produces another empty read on every iteration - the SUT must
@@ -647,11 +785,15 @@ TEST(AudioPipelineReadTest, LoopModeReplaysContent) {
  * pulling zero samples through an unending sequence of rewinds.
  */
 TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
-    FakeAudioSource source{AudioFormat{
-                               .channels   = 1,
-                               .sampleRate = kBroadcastRateHz,
-                           },
-                           true};
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    ON_CALL(source, seekable()).WillByDefault(::testing::Return(true));
+    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(0));
+    ON_CALL(source, rewind()).WillByDefault(::testing::Return(true));
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = true,
@@ -663,6 +805,38 @@ TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
     std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
 
     EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::End);
+}
+
+/**
+ * @brief Loop mode reports Error when source.rewind() fails on the boundary.
+ *
+ * Distinct from LoopModeReportsEndOnEmptySource, which exercises the rewind-then-empty path
+ * with rewind()=true. Here rewind() returns false on the first EOF, modelling a backend whose
+ * seekable() advertisement turned out to be a lie at the moment the seek was actually issued -
+ * the SUT must surface this as Error rather than swallowing the seek failure and falling
+ * through to End.
+ */
+TEST(AudioPipelineReadTest, ReportsErrorWhenLoopRewindFails) {
+    ::testing::NiceMock<MockAudioSource> source;
+    ON_CALL(source, format())
+        .WillByDefault(::testing::Return(AudioFormat{
+            .channels   = 1,
+            .sampleRate = kBroadcastRateHz,
+        }));
+    ON_CALL(source, seekable()).WillByDefault(::testing::Return(true));
+    ON_CALL(source, read(::testing::_)).WillByDefault(::testing::Return(0));
+    ON_CALL(source, rewind()).WillByDefault(::testing::Return(false));
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = true,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+
+    EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::Error);
 }
 
 /**

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -487,7 +487,12 @@ TEST(AudioPipelineReadTest, StereoMonoModeAveragesChannels) {
         samples[frame * 2 + 0] = 1.0F;
         samples[frame * 2 + 1] = 0.5F;
     }
-    FakeAudioSource source{AudioFormat{.channels = 2, .sampleRate = kBroadcastRateHz}, std::move(samples), true};
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 2,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           std::move(samples),
+                           true};
     AudioPipeline pipeline(source,
                            AudioPipelineConfig{
                                .loop               = false,

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -430,9 +430,9 @@ TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
  * the downmix collapses to a single-channel copy and AudioRateConverter takes its
  * passthrough fast path (libsoxr is not even instantiated), so any deviation beyond 1e-5
  * between the source and the output points to a regression in the pass-through path.
- * Comparison stops at the reference end; any trailing output the pipeline emits past that
- * point is drain padding rather than source content and is not part of the reproduction
- * contract.
+ * kFrames is a multiple of targetOutputFrames, so the source is consumed in whole blocks
+ * with no zero-pad tail; the reference-size guard on the inner loop is defensive against
+ * future tweaks to either constant and never short-circuits at the chosen values.
  */
 TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
     constexpr std::size_t kFrames{4096};

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -1,0 +1,737 @@
+/**
+ * @file test_audio_pipeline.cpp
+ * @brief Unit tests for validateAudioFormat, validateLoopSupport, and AudioPipeline.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 15.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <optional>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "audio_pipeline.h"
+#include "captured_streams_mixin.h"
+#include "fake_audio_source.h"
+
+namespace {
+    /**
+     * @brief Inclusive lower bound on the audio sample rate accepted by validateAudioFormat -
+     *        matches the lower end of the (8 kHz - 192 kHz) window declared by the project's
+     *        CLI front-ends.
+     */
+    constexpr int kMinSampleRateHz{8'000};
+
+    /**
+     * @brief Inclusive upper bound on the audio sample rate accepted by validateAudioFormat -
+     *        matches the upper end of the (8 kHz - 192 kHz) window declared by the project's
+     *        CLI front-ends.
+     */
+    constexpr int kMaxSampleRateHz{192'000};
+
+    /**
+     * @brief Broadcast sample rate (48 kHz). Default for every non-resample pipeline test
+     *        and for the mono validate case.
+     */
+    constexpr int kBroadcastRateHz{48'000};
+
+    /**
+     * @brief CD-audio sample rate (44.1 kHz). Paired with stereo on the stereo validate case
+     *        and used as the asymmetric peer of kBroadcastRateHz in the resample sweep.
+     */
+    constexpr int kCdAudioRateHz{44'100};
+}  // namespace
+
+namespace {
+    struct ValidateAudioFormatAcceptTestCase {
+        std::string_view name;
+        int channels;
+        int sampleRate;
+    };
+
+    /**
+     * @brief Render a ValidateAudioFormatAcceptTestCase as its name plus the (channels,
+     *        sampleRate) pair for gtest listings and failure messages.
+     */
+    void PrintTo(const ValidateAudioFormatAcceptTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {channels=" << testCase.channels << ", sampleRate=" << testCase.sampleRate << "}";
+    }
+
+    /**
+     * @brief Four accept cases covering both supported channel layouts and both inclusive
+     *        sample-rate boundaries: mono / stereo mid-range, mono at min boundary, mono at
+     *        max boundary. A regression that flipped the channel branch or shifted a boundary
+     *        by one Hz trips exactly the affected case.
+     */
+    std::vector<ValidateAudioFormatAcceptTestCase> makeValidateAudioFormatAcceptTestCases() {
+        return {
+            ValidateAudioFormatAcceptTestCase{"MonoBroadcast", 1, kBroadcastRateHz},
+            ValidateAudioFormatAcceptTestCase{"StereoCdAudio", 2, kCdAudioRateHz},
+            ValidateAudioFormatAcceptTestCase{"MonoAtMinBoundary", 1, kMinSampleRateHz},
+            ValidateAudioFormatAcceptTestCase{"MonoAtMaxBoundary", 1, kMaxSampleRateHz},
+        };
+    }
+}  // namespace
+
+class ValidateAudioFormatAcceptTest
+    : public CapturedStreamsMixin<::testing::TestWithParam<ValidateAudioFormatAcceptTestCase>> {};
+
+/**
+ * @brief Accepted format returns true and emits no stderr diagnostic.
+ *
+ * The stderr-empty check pins down the silent-success half of the contract: a regression
+ * that returned true while still emitting a warning would slip past a boolean-only check.
+ */
+TEST_P(ValidateAudioFormatAcceptTest, AcceptsAndStaysSilent) {
+    const auto& testCase{GetParam()};
+
+    const bool accepted{validateAudioFormat(
+        AudioFormat{
+            .channels   = testCase.channels,
+            .sampleRate = testCase.sampleRate,
+        },
+        kMinSampleRateHz,
+        kMaxSampleRateHz)};
+
+    EXPECT_TRUE(accepted);
+    EXPECT_TRUE(capturedStderr().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(InRange, ValidateAudioFormatAcceptTest,
+                         ::testing::ValuesIn(makeValidateAudioFormatAcceptTestCases()),
+                         [](const ::testing::TestParamInfo<ValidateAudioFormatAcceptTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct ValidateAudioFormatRejectTestCase {
+        std::string_view name;
+        int channels;
+        int sampleRate;
+        std::string_view diagnosticSubstring;
+    };
+
+    /**
+     * @brief Render a ValidateAudioFormatRejectTestCase as its name plus the (channels,
+     *        sampleRate) pair for gtest listings and failure messages.
+     */
+    void PrintTo(const ValidateAudioFormatRejectTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {channels=" << testCase.channels << ", sampleRate=" << testCase.sampleRate << "}";
+    }
+
+    /**
+     * @brief Two cases per rejection branch in the SUT: the channel branch with zero and five
+     *        channels (covering "below 1" and "above 2"), the range branch with one Hz outside
+     *        each inclusive boundary. diagnosticSubstring pins the stderr text to its branch,
+     *        catching a regression where the wrong branch's message fires.
+     */
+    std::vector<ValidateAudioFormatRejectTestCase> makeValidateAudioFormatRejectTestCases() {
+        return {
+            ValidateAudioFormatRejectTestCase{"ZeroChannels", 0, kBroadcastRateHz, "mono or stereo"},
+            ValidateAudioFormatRejectTestCase{"FiveChannels", 5, kBroadcastRateHz, "mono or stereo"},
+            ValidateAudioFormatRejectTestCase{
+                "RateBelowMinimum", 1, kMinSampleRateHz - 1, "outside the supported range"},
+            ValidateAudioFormatRejectTestCase{
+                "RateAboveMaximum", 1, kMaxSampleRateHz + 1, "outside the supported range"},
+        };
+    }
+}  // namespace
+
+class ValidateAudioFormatRejectTest
+    : public CapturedStreamsMixin<::testing::TestWithParam<ValidateAudioFormatRejectTestCase>> {};
+
+/**
+ * @brief Rejected format returns false and emits the branch-specific stderr diagnostic.
+ *
+ * The substring check pins the diagnostic to its rejection branch instead of accepting any
+ * non-empty stderr; together with the boolean-return assertion this catches both a wrong-branch
+ * regression and a silent rejection that forgot the diagnostic entirely.
+ */
+TEST_P(ValidateAudioFormatRejectTest, RejectsAndEmitsBranchSpecificDiagnostic) {
+    const auto& testCase{GetParam()};
+
+    const bool accepted{validateAudioFormat(
+        AudioFormat{
+            .channels   = testCase.channels,
+            .sampleRate = testCase.sampleRate,
+        },
+        kMinSampleRateHz,
+        kMaxSampleRateHz)};
+
+    EXPECT_FALSE(accepted);
+    EXPECT_NE(capturedStderr().find(testCase.diagnosticSubstring), std::string::npos);
+}
+
+INSTANTIATE_TEST_SUITE_P(OutOfRange, ValidateAudioFormatRejectTest,
+                         ::testing::ValuesIn(makeValidateAudioFormatRejectTestCases()),
+                         [](const ::testing::TestParamInfo<ValidateAudioFormatRejectTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct ValidateLoopSupportTestCase {
+        std::string_view name;
+        bool seekable;
+        bool loopRequested;
+        bool expectedAccepted;
+        std::optional<std::string_view> diagnosticSubstring;  ///< std::nullopt on accept cases.
+    };
+
+    /**
+     * @brief Render a ValidateLoopSupportTestCase as its name plus the (seekable, loopRequested)
+     *        pair for gtest listings and failure messages. std::boolalpha keeps the booleans
+     *        readable in failure output ("seekable=false" rather than "seekable=0").
+     */
+    void PrintTo(const ValidateLoopSupportTestCase& testCase, std::ostream* os) {
+        *os << std::boolalpha << testCase.name << " {seekable=" << testCase.seekable
+            << ", loopRequested=" << testCase.loopRequested << "}";
+    }
+
+    /**
+     * @brief Full 2x2 truth table over (seekable x loopRequested). The loop-not-requested
+     *        branch short-circuits to accept regardless of seekable; the loop-requested branch
+     *        accepts only when seekable. The single rejection corner (loopRequested=true,
+     *        seekable=false) emits a "not seekable" diagnostic. The std::nullopt diagnostic on
+     *        the three accept cases drives the per-case stderr-empty assertion in the body.
+     */
+    std::vector<ValidateLoopSupportTestCase> makeValidateLoopSupportTestCases() {
+        return {
+            ValidateLoopSupportTestCase{"NoLoopOnNonSeekable", false, false, true, std::nullopt},
+            ValidateLoopSupportTestCase{"NoLoopOnSeekable", true, false, true, std::nullopt},
+            ValidateLoopSupportTestCase{"LoopOnSeekable", true, true, true, std::nullopt},
+            ValidateLoopSupportTestCase{"LoopOnNonSeekable", false, true, false, "not seekable"},
+        };
+    }
+}  // namespace
+
+class ValidateLoopSupportTest : public CapturedStreamsMixin<::testing::TestWithParam<ValidateLoopSupportTestCase>> {};
+
+/**
+ * @brief Decision and diagnostic match the per-case truth-table outcome.
+ *
+ * Sweep over the four (seekable, loopRequested) combinations: three accept silently and the
+ * remaining (loopRequested=true, seekable=false) corner rejects with a "not seekable"
+ * diagnostic. The accept/reject shape of the stderr check is keyed by whether the case
+ * carries an expected diagnosticSubstring, so each case owns its full expected outcome.
+ */
+TEST_P(ValidateLoopSupportTest, MatchesExpectedOutcome) {
+    const auto& testCase{GetParam()};
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           testCase.seekable};
+
+    const bool accepted{validateLoopSupport(source, testCase.loopRequested)};
+
+    EXPECT_EQ(accepted, testCase.expectedAccepted);
+    if (testCase.diagnosticSubstring.has_value()) {
+        EXPECT_NE(capturedStderr().find(testCase.diagnosticSubstring.value()), std::string::npos);
+    } else {
+        EXPECT_TRUE(capturedStderr().empty());
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(TruthTable, ValidateLoopSupportTest, ::testing::ValuesIn(makeValidateLoopSupportTestCases()),
+                         [](const ::testing::TestParamInfo<ValidateLoopSupportTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct AudioPipelineCtorRejectionTestCase {
+        std::string_view name;
+        int sourceChannels;
+        std::size_t targetOutputFrames;
+    };
+
+    /**
+     * @brief Render an AudioPipelineCtorRejectionTestCase as its name plus the (sourceChannels,
+     *        targetOutputFrames) pair for gtest listings and failure messages.
+     */
+    void PrintTo(const AudioPipelineCtorRejectionTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {sourceChannels=" << testCase.sourceChannels
+            << ", targetOutputFrames=" << testCase.targetOutputFrames << "}";
+    }
+
+    /**
+     * @brief One case per rejection branch in the ctor: zero source channels is rejected by
+     *        the AudioPipeline ctor's own channel-count check before any rate-converter
+     *        construction; zero target output frames propagates std::invalid_argument from
+     *        the per-channel AudioRateConverter the pipeline constructs internally. Surfacing
+     *        the same exception type from both branches keeps the rejection contract uniform
+     *        for the caller.
+     */
+    std::vector<AudioPipelineCtorRejectionTestCase> makeAudioPipelineCtorRejectionTestCases() {
+        return {
+            AudioPipelineCtorRejectionTestCase{"ZeroChannels", 0, 1024},
+            AudioPipelineCtorRejectionTestCase{"ZeroTargetOutputFrames", 1, 0},
+        };
+    }
+}  // namespace
+
+class AudioPipelineCtorTest : public ::testing::TestWithParam<AudioPipelineCtorRejectionTestCase> {};
+
+/**
+ * @brief Ctor throws std::invalid_argument for any rejected config combination.
+ *
+ * The exception type is uniform across the two rejection branches (channel-count check in
+ * AudioPipeline::AudioPipeline; targetOutputFrames check in the per-channel
+ * AudioRateConverter ctor), so the test does not need to differentiate which branch fired -
+ * surfacing std::invalid_argument from any rejected config is the public contract.
+ */
+TEST_P(AudioPipelineCtorTest, ThrowsInvalidArgument) {
+    const auto& testCase{GetParam()};
+    FakeAudioSource source{AudioFormat{
+                               .channels   = testCase.sourceChannels,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           true};
+
+    EXPECT_THROW(
+        {
+            [[maybe_unused]] AudioPipeline pipeline(source,
+                                                    AudioPipelineConfig{
+                                                        .loop               = false,
+                                                        .targetSampleRate   = kBroadcastRateHz,
+                                                        .targetOutputFrames = testCase.targetOutputFrames,
+                                                        .channelMode        = AudioChannelMode::Mono,
+                                                    });
+        },
+        std::invalid_argument);
+}
+
+INSTANTIATE_TEST_SUITE_P(RejectedConfig, AudioPipelineCtorTest,
+                         ::testing::ValuesIn(makeAudioPipelineCtorRejectionTestCases()),
+                         [](const ::testing::TestParamInfo<AudioPipelineCtorRejectionTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct OutputGeometryTestCase {
+        std::string_view name;
+        int sourceChannels;
+        AudioChannelMode channelMode;
+        std::size_t targetOutputFrames;
+        int expectedOutputChannels;
+        std::size_t expectedOutputSamplesPerBlock;
+    };
+
+    /**
+     * @brief Render an OutputGeometryTestCase as its name plus the (sourceChannels, channelMode,
+     *        targetOutputFrames) triple for gtest listings.
+     */
+    void PrintTo(const OutputGeometryTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {sourceChannels=" << testCase.sourceChannels
+            << ", channelMode=" << (testCase.channelMode == AudioChannelMode::Mono ? "Mono" : "Preserve")
+            << ", targetOutputFrames=" << testCase.targetOutputFrames << "}";
+    }
+
+    /**
+     * @brief Three cases covering the distinct output-geometry shapes the pipeline can produce:
+     *        downmix path (stereo source through Mono mode collapses to one channel), multichannel
+     *        passthrough (stereo source through Preserve mode keeps both channels), single-channel
+     *        passthrough (mono source through Preserve mode is trivial). The fourth (mono source,
+     *        Mono mode) combination is omitted because it yields the same output geometry as
+     *        (mono source, Preserve mode) and would not exercise a distinct branch.
+     *        expectedOutputSamplesPerBlock is outputChannels * targetOutputFrames - listing the
+     *        derived value explicitly lets the test catch a regression in either factor or in
+     *        the multiplication.
+     */
+    std::vector<OutputGeometryTestCase> makeOutputGeometryTestCases() {
+        return {
+            OutputGeometryTestCase{"StereoSourceMono", 2, AudioChannelMode::Mono, 512, 1, 512},
+            OutputGeometryTestCase{"StereoSourcePreserve", 2, AudioChannelMode::Preserve, 256, 2, 512},
+            OutputGeometryTestCase{"MonoSourcePreserve", 1, AudioChannelMode::Preserve, 256, 1, 256},
+        };
+    }
+}  // namespace
+
+class AudioPipelineOutputGeometryTest : public ::testing::TestWithParam<OutputGeometryTestCase> {};
+
+/**
+ * @brief Output channel count, frame count, and samples-per-block follow channelMode and targetOutputFrames.
+ *
+ * Mono mode collapses any source-channel count to 1; Preserve mode passes the source-channel
+ * count through. outputSamplesPerBlock() multiplies frames by the resulting channel count -
+ * checking that derived value alongside the two primary getters catches a regression in
+ * either factor or the multiplication itself.
+ */
+TEST_P(AudioPipelineOutputGeometryTest, ReportsExpectedOutputDimensions) {
+    const auto& testCase{GetParam()};
+    FakeAudioSource source{AudioFormat{
+                               .channels   = testCase.sourceChannels,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = testCase.targetOutputFrames,
+                               .channelMode        = testCase.channelMode,
+                           });
+
+    EXPECT_EQ(pipeline.outputChannels(), testCase.expectedOutputChannels);
+    EXPECT_EQ(pipeline.outputFrames(), testCase.targetOutputFrames);
+    EXPECT_EQ(pipeline.outputSamplesPerBlock(), testCase.expectedOutputSamplesPerBlock);
+}
+
+INSTANTIATE_TEST_SUITE_P(ChannelModeMatrix, AudioPipelineOutputGeometryTest,
+                         ::testing::ValuesIn(makeOutputGeometryTestCases()),
+                         [](const ::testing::TestParamInfo<OutputGeometryTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+/**
+ * @brief read() throws std::invalid_argument when the destination size is not outputSamplesPerBlock().
+ *
+ * The output buffer must exactly match the geometry declared by the ctor. The two EXPECT_THROW
+ * calls probe the `!=` check from both sides - one sample undersize and one sample oversize -
+ * which catches an off-by-one regression that a single far-from-boundary check (e.g. size=64
+ * against expected 1024) would let slip through.
+ */
+TEST(AudioPipelineReadTest, ThrowsOnMismatchedOutputBlockSize) {
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+    std::vector<float> undersizedOutputBlock(pipeline.outputSamplesPerBlock() - 1, 0.0F);
+    std::vector<float> oversizedOutputBlock(pipeline.outputSamplesPerBlock() + 1, 0.0F);
+
+    EXPECT_THROW(
+        { [[maybe_unused]] const AudioPipelineStatus status{pipeline.read(undersizedOutputBlock)}; },
+        std::invalid_argument);
+    EXPECT_THROW(
+        { [[maybe_unused]] const AudioPipelineStatus status{pipeline.read(oversizedOutputBlock)}; },
+        std::invalid_argument);
+}
+
+/**
+ * @brief Mono passthrough reproduces the input sample-by-sample within a 1e-5 tolerance.
+ *
+ * Equal source/target rate plus mono-mode on a mono source minimizes per-sample arithmetic:
+ * the downmix collapses to a single-channel copy and AudioRateConverter takes its
+ * passthrough fast path (libsoxr is not even instantiated), so any deviation beyond 1e-5
+ * between the source and the output points to a regression in the pass-through path.
+ * Comparison stops at the reference end; any trailing output the pipeline emits past that
+ * point is drain padding rather than source content and is not part of the reproduction
+ * contract.
+ */
+TEST(AudioPipelineReadTest, MonoPassthroughReproducesInput) {
+    constexpr std::size_t kFrames{4096};
+    std::vector<float> samples(kFrames);
+    for (std::size_t frame{0}; frame < kFrames; ++frame) {
+        samples[frame] = static_cast<float>(frame) / static_cast<float>(kFrames) * 0.5F;
+    }
+    const auto referenceSamples{samples};
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           std::move(samples),
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 99.0F);
+    std::size_t comparedSampleCount{0};
+    while (true) {
+        const auto status{pipeline.read(outputBlock)};
+        if (status == AudioPipelineStatus::End) {
+            break;
+        }
+        ASSERT_EQ(status, AudioPipelineStatus::Ok);
+        for (std::size_t sampleIdx{0}; sampleIdx < outputBlock.size() && comparedSampleCount < referenceSamples.size();
+             ++sampleIdx, ++comparedSampleCount) {
+            EXPECT_NEAR(outputBlock[sampleIdx], referenceSamples[comparedSampleCount], 1e-5F)
+                << "Mismatch at sample " << comparedSampleCount;
+        }
+    }
+    EXPECT_EQ(comparedSampleCount, referenceSamples.size());
+}
+
+/**
+ * @brief Stereo source through Mono mode averages L and R to the arithmetic mean of the channel levels.
+ *
+ * Every source frame is filled with (L=1.0, R=0.5), so a correct arithmetic-mean downmix
+ * produces 0.75 for every output sample. The asymmetric levels are deliberate: a regression
+ * that returned only the first channel (1.0) or only the second (0.5) trips the EXPECT_NEAR,
+ * and so does a sum-without-scaling bug (1.5) or a sign-flip on the average (-0.75). A
+ * symmetric (L=+1, R=-1) fixture would average to zero and let sum-without-scaling and
+ * sign-flip regressions slip through silently.
+ */
+TEST(AudioPipelineReadTest, StereoMonoModeAveragesChannels) {
+    constexpr std::size_t kFrames{2048};
+    std::vector<float> samples(kFrames * 2);
+    for (std::size_t frame{0}; frame < kFrames; ++frame) {
+        samples[frame * 2 + 0] = 1.0F;
+        samples[frame * 2 + 1] = 0.5F;
+    }
+    FakeAudioSource source{AudioFormat{.channels = 2, .sampleRate = kBroadcastRateHz}, std::move(samples), true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 99.0F);
+    const auto status{pipeline.read(outputBlock)};
+
+    ASSERT_EQ(status, AudioPipelineStatus::Ok);
+    for (float sample: outputBlock) {
+        EXPECT_NEAR(sample, 0.75F, 1e-5F);
+    }
+}
+
+/**
+ * @brief Stereo source through Preserve mode passes each channel through independently.
+ *
+ * Every source frame is filled with (L=0.25, R=-0.5); Preserve mode must leave both
+ * components untouched on the output. A regression that downmixed despite Preserve mode
+ * would average the two to -0.125 and trip the EXPECT_NEAR on both interleaved slots.
+ */
+TEST(AudioPipelineReadTest, StereoPreserveModePropagatesIndependentChannels) {
+    constexpr std::size_t kFrames{2048};
+    std::vector<float> samples(kFrames * 2);
+    for (std::size_t frame{0}; frame < kFrames; ++frame) {
+        samples[frame * 2 + 0] = 0.25F;
+        samples[frame * 2 + 1] = -0.5F;
+    }
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 2,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           std::move(samples),
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Preserve,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 99.0F);
+    const auto status{pipeline.read(outputBlock)};
+
+    ASSERT_EQ(status, AudioPipelineStatus::Ok);
+    for (std::size_t sampleIdx{0}; sampleIdx + 1 < outputBlock.size(); sampleIdx += 2) {
+        EXPECT_NEAR(outputBlock[sampleIdx + 0], 0.25F, 1e-5F);
+        EXPECT_NEAR(outputBlock[sampleIdx + 1], -0.5F, 1e-5F);
+    }
+}
+
+/**
+ * @brief read() returns Error when the source already has its sticky error flag raised on the first read.
+ *
+ * FakeAudioSource publishes error()=true at the same call that returns 0 samples, so the
+ * pipeline reader hits the error-during-zero-read path and reports Error rather than End -
+ * distinguishing a fatal I/O failure from a clean EOF on the same zero-sample return.
+ */
+TEST(AudioPipelineReadTest, ReportsErrorWhenSourceErrorFlagIsSet) {
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           true};
+    source.setError(true);
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+
+    EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::Error);
+}
+
+/**
+ * @brief Non-loop pipeline on an empty source returns End on the first read and stays at End thereafter.
+ *
+ * The first EXPECT pins down the empty short-circuit: no silence block or Ok with garbage on
+ * a missing-input source. The second pins down the latched-End invariant: the drained flag
+ * stays set and subsequent reads continue returning End instead of attempting to restart.
+ */
+TEST(AudioPipelineReadTest, NonLoopOnEmptySourceReturnsEndAndStays) {
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+
+    EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::End);
+    EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::End);
+}
+
+/**
+ * @brief Loop mode replays content from a seekable source across multiple blocks without ever reporting End.
+ *
+ * Source content is intentionally shorter than a single output block (600 frames vs 1024
+ * samples per call) so every read() requires at least one rewind to fill the block,
+ * exercising the loop boundary path multiple times across the five iterations.
+ */
+TEST(AudioPipelineReadTest, LoopModeReplaysContent) {
+    constexpr std::size_t kSourceFrames{600};
+    constexpr int kIterations{5};
+    std::vector<float> samples(kSourceFrames, 0.5F);
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           std::move(samples),
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = true,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+    for (int blockIdx{0}; blockIdx < kIterations; ++blockIdx) {
+        EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::Ok);
+    }
+}
+
+/**
+ * @brief Loop mode on an empty seekable source reports End instead of livelocking on empty replays.
+ *
+ * Rewinding an empty source produces another empty read on every iteration - the SUT must
+ * detect "no progress after rewind" and convert it to End rather than spinning forever
+ * pulling zero samples through an unending sequence of rewinds.
+ */
+TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = true,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+
+    EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::End);
+}
+
+namespace {
+    struct ResampleTestCase {
+        std::string_view name;
+        int sourceRate;
+        int targetRate;
+    };
+
+    /**
+     * @brief Render a ResampleTestCase as its name plus the (sourceRate -> targetRate) pair
+     *        for gtest listings.
+     */
+    void PrintTo(const ResampleTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {" << testCase.sourceRate << " -> " << testCase.targetRate << "}";
+    }
+
+    /**
+     * @brief Four characteristic rate-conversion regimes the pipeline must handle: a same-rate
+     *        passthrough, the canonical 44.1 / 48 kHz upsample, its symmetric downsample, and
+     *        a large upsample into the project's broadcast ceiling. Same canonical pairing as
+     *        the SoxrResampler and AudioRateConverter test suites.
+     */
+    std::vector<ResampleTestCase> makeResampleTestCases() {
+        return {
+            ResampleTestCase{"Passthrough48k", kBroadcastRateHz, kBroadcastRateHz},
+            ResampleTestCase{"Upsample441kTo48k", kCdAudioRateHz, kBroadcastRateHz},
+            ResampleTestCase{"Downsample48kTo441k", kBroadcastRateHz, kCdAudioRateHz},
+            ResampleTestCase{"LargeUpsample441kTo192k", kCdAudioRateHz, kMaxSampleRateHz},
+        };
+    }
+}  // namespace
+
+class AudioPipelineResampleSweepTest : public ::testing::TestWithParam<ResampleTestCase> {};
+
+/**
+ * @brief Total output sample count is approximately sourceFrames * targetRate / sourceRate.
+ *
+ * The expected count derives from the rate ratio applied to the source frame budget; the 10%
+ * tolerance absorbs libsoxr's warmup padding on the first block and drain padding on the
+ * last block (each up to outputFrames silence samples). A regression that dropped input
+ * mid-stream or emitted runaway blocks would exceed the tolerance and surface on the
+ * EXPECT_NEAR.
+ */
+TEST_P(AudioPipelineResampleSweepTest, EmitsTargetRateBlocksWithoutInputDrop) {
+    constexpr std::size_t kSourceFrames{16'384};
+    const auto& testCase{GetParam()};
+    std::vector<float> samples(kSourceFrames, 0.5F);
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = testCase.sourceRate,
+                           },
+                           std::move(samples),
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = testCase.targetRate,
+                               .targetOutputFrames = 1024,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+    std::size_t totalSamples{0};
+    while (true) {
+        const auto status{pipeline.read(outputBlock)};
+        if (status == AudioPipelineStatus::End) {
+            break;
+        }
+        ASSERT_EQ(status, AudioPipelineStatus::Ok);
+        totalSamples += outputBlock.size();
+    }
+    const double expected{static_cast<double>(kSourceFrames) * testCase.targetRate / testCase.sourceRate};
+    EXPECT_NEAR(static_cast<double>(totalSamples), expected, expected * 0.10);
+}
+
+INSTANTIATE_TEST_SUITE_P(RatioMatrix, AudioPipelineResampleSweepTest, ::testing::ValuesIn(makeResampleTestCases()),
+                         [](const ::testing::TestParamInfo<ResampleTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -606,7 +606,7 @@ TEST(AudioPipelineReadTest, NonLoopOnEmptySourceReturnsEndAndStays) {
  */
 TEST(AudioPipelineReadTest, LoopModeReplaysContent) {
     constexpr std::size_t kSourceFrames{600};
-    constexpr int kIterations{5};
+    constexpr std::size_t kIterations{5};
     std::vector<float> samples(kSourceFrames, 0.5F);
     FakeAudioSource source{AudioFormat{
                                .channels   = 1,
@@ -623,7 +623,7 @@ TEST(AudioPipelineReadTest, LoopModeReplaysContent) {
                            });
 
     std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
-    for (int blockIdx{0}; blockIdx < kIterations; ++blockIdx) {
+    for (std::size_t blockIdx{0}; blockIdx < kIterations; ++blockIdx) {
         EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::Ok);
     }
 }

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -657,6 +657,47 @@ TEST(AudioPipelineReadTest, LoopModeReportsEndOnEmptySource) {
     EXPECT_EQ(pipeline.read(outputBlock), AudioPipelineStatus::End);
 }
 
+/**
+ * @brief Passthrough emits exactly the source frame count.
+ *
+ * Equal source/target rate routes AudioRateConverter to its passthrough fast path - no
+ * libsoxr, no warmup / drain padding. With kSourceFrames a multiple of targetOutputFrames
+ * block-rounding adds nothing either, pinning the total to kSourceFrames bit-for-bit -
+ * a regression that spuriously built soxr on an equal-rate config trips the EXPECT_EQ that
+ * AudioPipelineResampleSweepTest's 10% tolerance would mask.
+ */
+TEST(AudioPipelineReadTest, PassthroughEmitsExactSourceFrameCount) {
+    constexpr std::size_t kSourceFrames{16'384};
+    constexpr std::size_t kTargetOutputFrames{1'024};
+    std::vector<float> samples(kSourceFrames, 0.5F);
+    FakeAudioSource source{AudioFormat{
+                               .channels   = 1,
+                               .sampleRate = kBroadcastRateHz,
+                           },
+                           std::move(samples),
+                           true};
+    AudioPipeline pipeline(source,
+                           AudioPipelineConfig{
+                               .loop               = false,
+                               .targetSampleRate   = kBroadcastRateHz,
+                               .targetOutputFrames = kTargetOutputFrames,
+                               .channelMode        = AudioChannelMode::Mono,
+                           });
+
+    std::vector<float> outputBlock(pipeline.outputSamplesPerBlock(), 0.0F);
+    std::size_t totalSamples{0};
+    while (true) {
+        const auto status{pipeline.read(outputBlock)};
+        if (status == AudioPipelineStatus::End) {
+            break;
+        }
+        ASSERT_EQ(status, AudioPipelineStatus::Ok);
+        totalSamples += outputBlock.size();
+    }
+
+    EXPECT_EQ(totalSamples, kSourceFrames);
+}
+
 namespace {
     struct ResampleTestCase {
         std::string_view name;
@@ -673,14 +714,16 @@ namespace {
     }
 
     /**
-     * @brief Four characteristic rate-conversion regimes the pipeline must handle: a same-rate
-     *        passthrough, the canonical 44.1 / 48 kHz upsample, its symmetric downsample, and
-     *        a large upsample into the project's broadcast ceiling. Same canonical pairing as
-     *        the SoxrResampler and AudioRateConverter test suites.
+     * @brief Three rate-converting regimes the pipeline must handle: the canonical 44.1 /
+     *        48 kHz upsample, its symmetric downsample, and a large upsample into the
+     *        project's broadcast ceiling. Same canonical pairing as the SoxrResampler and
+     *        AudioRateConverter test suites. The same-rate passthrough configuration is
+     *        covered exact-match by PassthroughEmitsExactSourceFrameCount instead - libsoxr is
+     *        never instantiated on that path, so the 10% warmup / drain budget carried by the
+     *        sweep below would be meaninglessly generous there.
      */
     std::vector<ResampleTestCase> makeResampleTestCases() {
         return {
-            ResampleTestCase{"Passthrough48k", kBroadcastRateHz, kBroadcastRateHz},
             ResampleTestCase{"Upsample441kTo48k", kCdAudioRateHz, kBroadcastRateHz},
             ResampleTestCase{"Downsample48kTo441k", kBroadcastRateHz, kCdAudioRateHz},
             ResampleTestCase{"LargeUpsample441kTo192k", kCdAudioRateHz, kMaxSampleRateHz},

--- a/src/utils/audio/tests/test_audio_pipeline.cpp
+++ b/src/utils/audio/tests/test_audio_pipeline.cpp
@@ -279,7 +279,8 @@ namespace {
     }
 }  // namespace
 
-class AudioPipelineCtorTest : public ::testing::TestWithParam<AudioPipelineCtorRejectionTestCase> {};
+class AudioPipelineCtorTest
+    : public CapturedStreamsMixin<::testing::TestWithParam<AudioPipelineCtorRejectionTestCase>> {};
 
 /**
  * @brief Ctor throws std::invalid_argument for any rejected config combination.
@@ -353,7 +354,8 @@ namespace {
     }
 }  // namespace
 
-class AudioPipelineOutputGeometryTest : public ::testing::TestWithParam<OutputGeometryTestCase> {};
+class AudioPipelineOutputGeometryTest : public CapturedStreamsMixin<::testing::TestWithParam<OutputGeometryTestCase>> {
+};
 
 /**
  * @brief Output channel count, frame count, and samples-per-block follow channelMode and targetOutputFrames.

--- a/src/utils/audio/tests/test_audio_rate_converter.cpp
+++ b/src/utils/audio/tests/test_audio_rate_converter.cpp
@@ -141,9 +141,6 @@ TEST(AudioRateConverterTest, PassthroughLeavesSamplesIntact) {
 
 /**
  * @brief process() reports success when the buffers match the converter's geometry.
- *
- * Sizing both spans from peekNextInputFrames and outputFrames satisfies the contract;
- * the call returns true.
  */
 TEST(AudioRateConverterTest, ProcessSucceedsOnRealRateConversion) {
     AudioRateConverter audioRateConverter{kCdAudioRateHz, kBroadcastRateHz, kDefaultOutputFrames};

--- a/src/utils/audio/tests/test_audio_rate_converter.cpp
+++ b/src/utils/audio/tests/test_audio_rate_converter.cpp
@@ -1,0 +1,326 @@
+/**
+ * @file test_audio_rate_converter.cpp
+ * @brief Unit tests for the AudioRateConverter wrapper around SoxrResampler.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 12.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "audio_rate_converter.h"
+
+namespace {
+    /**
+     * @brief CD-audio source rate (44.1 kHz). Paired with kBroadcastRateHz on the
+     *        rate-converting path.
+     */
+    constexpr int kCdAudioRateHz{44'100};
+
+    /**
+     * @brief Broadcast target rate (48 kHz). Same value on both source and target
+     *        trips the passthrough fast path.
+     */
+    constexpr int kBroadcastRateHz{48'000};
+
+    /**
+     * @brief Output block size used across the suite. 1024 is large enough for the
+     *        rate-ratio math to produce meaningful Bresenham alternation and small
+     *        enough to keep test input vectors trivially cheap to allocate.
+     */
+    constexpr std::size_t kDefaultOutputFrames{1024};
+
+    /**
+     * @brief Upper alternation value of peekNextInputFrames at the 44.1 -> 48 kHz pair
+     *        with kDefaultOutputFrames. The 44100:48000 = 147:160 ratio gives an exact
+     *        per-call average of 940.8 input frames; ceil(1024 * 44100 / 48000) = 941
+     *        sets the ceiling that maxInputFrames() reports. Paired with
+     *        kCdToBroadcastMinInputFrames.
+     */
+    constexpr std::size_t kCdToBroadcastMaxInputFrames{941};
+
+    /**
+     * @brief Lower alternation value of peekNextInputFrames at the same pair:
+     *        floor(1024 * 44100 / 48000) = 940. Defined as Max - 1 so the floor/ceiling
+     *        relationship stays explicit and immune to manual drift.
+     */
+    constexpr std::size_t kCdToBroadcastMinInputFrames{kCdToBroadcastMaxInputFrames - 1};
+}  // namespace
+
+/**
+ * @brief Passthrough mode collapses every geometry getter to outputFrames.
+ *
+ * When sourceRateHz == targetRateHz the constructor skips soxr instantiation, so
+ * peekNextInputFrames must match outputFrames on every call - each input block
+ * maps 1:1 to the matching output block without any Bresenham bookkeeping.
+ */
+TEST(AudioRateConverterTest, PassthroughExposesSymmetricGeometry) {
+    AudioRateConverter audioRateConverter{kBroadcastRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+
+    EXPECT_EQ(audioRateConverter.outputFrames(), kDefaultOutputFrames);
+    EXPECT_EQ(audioRateConverter.maxInputFrames(), kDefaultOutputFrames);
+    EXPECT_EQ(audioRateConverter.peekNextInputFrames(), kDefaultOutputFrames);
+}
+
+/**
+ * @brief maxInputFrames matches the documented ceiling and bounds the initial peek.
+ *
+ * EXPECT_EQ checks the ceiling against kCdToBroadcastMaxInputFrames. The EXPECT_LE is
+ * a state-zero sanity check that the initial peek fits the [0, maxInputFrames()] range;
+ * the full Bresenham trajectory across many process() calls is covered by
+ * BresenhamOscillatesBetweenTwoConsecutiveValues.
+ */
+TEST(AudioRateConverterTest, MaxInputBoundedByCeiledRatio) {
+    AudioRateConverter audioRateConverter{kCdAudioRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+
+    EXPECT_EQ(audioRateConverter.maxInputFrames(), kCdToBroadcastMaxInputFrames);
+    EXPECT_LE(audioRateConverter.peekNextInputFrames(), audioRateConverter.maxInputFrames());
+}
+
+/**
+ * @brief Bresenham accumulator alternates per-call input between two consecutive integers.
+ *
+ * For 44100 -> 48000 with kDefaultOutputFrames the exact average input per call is 940.8,
+ * so the Bresenham accumulator must alternate peekNextInputFrames between
+ * kCdToBroadcastMinInputFrames (940) and kCdToBroadcastMaxInputFrames (941) - never a third
+ * value - to keep the cumulative input/output ratio drift-free. 100 iterations both confirm
+ * the two-value oscillation and assert that nothing else leaks through.
+ */
+TEST(AudioRateConverterTest, BresenhamOscillatesBetweenTwoConsecutiveValues) {
+    AudioRateConverter audioRateConverter{kCdAudioRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+    std::vector<float> inputSamples;
+    std::vector<float> outputSamples(audioRateConverter.outputFrames(), 0.0F);
+
+    constexpr int kBresenhamIterations{100};
+    int floorObservations{0};
+    int ceilingObservations{0};
+    for (int i{0}; i < kBresenhamIterations; ++i) {
+        const std::size_t expectedInputFrames{audioRateConverter.peekNextInputFrames()};
+        if (expectedInputFrames == kCdToBroadcastMinInputFrames) {
+            ++floorObservations;
+        } else if (expectedInputFrames == kCdToBroadcastMaxInputFrames) {
+            ++ceilingObservations;
+        }
+        inputSamples.assign(expectedInputFrames, 0.0F);
+        ASSERT_TRUE(audioRateConverter.process(inputSamples, outputSamples));
+    }
+
+    EXPECT_GT(floorObservations, 0);
+    EXPECT_GT(ceilingObservations, 0);
+    EXPECT_EQ(floorObservations + ceilingObservations, kBresenhamIterations);
+}
+
+/**
+ * @brief Passthrough process() copies the input span element-wise into output.
+ *
+ * Distinguishable per-sample values (1..8) verify that no arithmetic, scaling, or
+ * silence padding has been applied - input and output buffers must compare equal
+ * after the call. An all-zero input would still pass a no-op buggy implementation,
+ * so a non-trivial pattern is required to catch a fill-with-zero regression.
+ */
+TEST(AudioRateConverterTest, PassthroughLeavesSamplesIntact) {
+    constexpr std::size_t kDistinctSampleCount{8};
+    AudioRateConverter audioRateConverter{kBroadcastRateHz, kBroadcastRateHz, kDistinctSampleCount};
+    std::vector<float> inputSamples{1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F};
+    std::vector<float> outputSamples(kDistinctSampleCount, 0.0F);
+
+    ASSERT_TRUE(audioRateConverter.process(inputSamples, outputSamples));
+
+    EXPECT_EQ(inputSamples, outputSamples);
+}
+
+/**
+ * @brief process() reports success when the buffers match the converter's geometry.
+ *
+ * Sizing both spans from peekNextInputFrames and outputFrames satisfies the contract;
+ * the call returns true.
+ */
+TEST(AudioRateConverterTest, ProcessSucceedsOnRealRateConversion) {
+    AudioRateConverter audioRateConverter{kCdAudioRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+    std::vector<float> inputSamples(audioRateConverter.peekNextInputFrames(), 0.0F);
+    std::vector<float> outputSamples(audioRateConverter.outputFrames(), 0.0F);
+
+    EXPECT_TRUE(audioRateConverter.process(inputSamples, outputSamples));
+}
+
+/**
+ * @brief Passthrough drain() reports success and emits zero frames.
+ *
+ * Without a soxr instance there is no filter tail and no spill to flush, so drain() returns
+ * a present optional holding 0. nullopt would signal a hard pipeline failure which the
+ * passthrough path cannot produce.
+ */
+TEST(AudioRateConverterTest, PassthroughDrainProducesZeroFrames) {
+    AudioRateConverter audioRateConverter{kBroadcastRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+    std::vector<float> outputSamples(audioRateConverter.outputFrames(), 0.0F);
+
+    const auto produced{audioRateConverter.drain(outputSamples)};
+
+    ASSERT_TRUE(produced.has_value());
+    EXPECT_EQ(produced.value(), 0U);
+}
+
+/**
+ * @brief drain() returns a present optional after real-rate processing.
+ *
+ * Ten blocks of constant DC populate soxr's filter delay line. The exact tail length the
+ * converter then emits depends on internal libsoxr state and is not a stable contract; the
+ * stable contracts are that drain() succeeds (non-nullopt) and that the reported frame
+ * count never exceeds the caller's buffer.
+ */
+TEST(AudioRateConverterTest, DrainSucceedsAfterRealConversion) {
+    AudioRateConverter audioRateConverter{kCdAudioRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+    std::vector<float> inputSamples;
+    std::vector<float> outputSamples(audioRateConverter.outputFrames(), 0.0F);
+
+    constexpr int kDelayLinePrimingBlocks{10};
+    for (int i{0}; i < kDelayLinePrimingBlocks; ++i) {
+        inputSamples.assign(audioRateConverter.peekNextInputFrames(), 1.0F);
+        ASSERT_TRUE(audioRateConverter.process(inputSamples, outputSamples));
+    }
+
+    const auto produced{audioRateConverter.drain(outputSamples)};
+
+    ASSERT_TRUE(produced.has_value());
+    EXPECT_LE(produced.value(), outputSamples.size());
+}
+
+/**
+ * @brief reset() preserves the Bresenham accumulator across a loop boundary.
+ *
+ * Discarding the filter delay line and spill is necessary so the end-of-file tail does not
+ * smear into the next iteration. Preserving the Bresenham accumulator is necessary so
+ * peekNextInputFrames after the reset still names the same input-frame count the caller has
+ * already fetched at the boundary - otherwise a looped playback accumulates sample-count
+ * drift across iterations.
+ */
+TEST(AudioRateConverterTest, ResetPreservesPeekAcrossLoopBoundary) {
+    AudioRateConverter audioRateConverter{kCdAudioRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+    std::vector<float> inputSamples(audioRateConverter.peekNextInputFrames(), 1.0F);
+    std::vector<float> outputSamples(audioRateConverter.outputFrames(), 0.0F);
+    ASSERT_TRUE(audioRateConverter.process(inputSamples, outputSamples));
+
+    const std::size_t peekBeforeReset{audioRateConverter.peekNextInputFrames()};
+    audioRateConverter.reset();
+
+    EXPECT_EQ(audioRateConverter.peekNextInputFrames(), peekBeforeReset);
+}
+
+namespace {
+    struct AudioRateConverterCtorRejectionTestCase {
+        std::string_view name;
+        int sourceRateHz;
+        int targetRateHz;
+        std::size_t targetOutputFrames;
+    };
+
+    /**
+     * @brief Render a ctor-rejection case as its name plus the offending parameter triple
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const AudioRateConverterCtorRejectionTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {sourceRateHz=" << testCase.sourceRateHz << ", targetRateHz=" << testCase.targetRateHz
+            << ", targetOutputFrames=" << testCase.targetOutputFrames << "}";
+    }
+
+    /**
+     * @brief Constructor parameter triples that violate the (sourceRateHz > 0,
+     *        targetRateHz > 0, targetOutputFrames > 0) precondition. One named case per
+     *        distinct violation channel; size_t cannot be negative so targetOutputFrames
+     *        has only the zero variant.
+     */
+    std::vector<AudioRateConverterCtorRejectionTestCase> makeAudioRateConverterCtorRejectionTestCases() {
+        return {
+            AudioRateConverterCtorRejectionTestCase{"SourceRateZero", 0, kBroadcastRateHz, kDefaultOutputFrames},
+            AudioRateConverterCtorRejectionTestCase{"SourceRateNegative", -1, kBroadcastRateHz, kDefaultOutputFrames},
+            AudioRateConverterCtorRejectionTestCase{"TargetRateZero", kBroadcastRateHz, 0, kDefaultOutputFrames},
+            AudioRateConverterCtorRejectionTestCase{"TargetRateNegative", kBroadcastRateHz, -1, kDefaultOutputFrames},
+            AudioRateConverterCtorRejectionTestCase{"OutputFramesZero", kBroadcastRateHz, kBroadcastRateHz, 0},
+        };
+    }
+}  // namespace
+
+class AudioRateConverterCtorRejectionTest : public ::testing::TestWithParam<AudioRateConverterCtorRejectionTestCase> {};
+
+/**
+ * @brief Every non-positive constructor parameter raises std::invalid_argument.
+ */
+TEST_P(AudioRateConverterCtorRejectionTest, ThrowsInvalidArgument) {
+    const auto& testCase{GetParam()};
+
+    EXPECT_THROW(AudioRateConverter(testCase.sourceRateHz, testCase.targetRateHz, testCase.targetOutputFrames),
+                 std::invalid_argument);
+}
+
+INSTANTIATE_TEST_SUITE_P(NonPositiveParameter, AudioRateConverterCtorRejectionTest,
+                         ::testing::ValuesIn(makeAudioRateConverterCtorRejectionTestCases()),
+                         [](const ::testing::TestParamInfo<AudioRateConverterCtorRejectionTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct AudioRateConverterProcessRejectionTestCase {
+        std::string_view name;
+        std::size_t inputSize;
+        std::size_t outputSize;
+    };
+
+    /**
+     * @brief Render a process-rejection case as its name and the two span sizes for gtest
+     *        listings and failure messages.
+     */
+    void PrintTo(const AudioRateConverterProcessRejectionTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {inputSize=" << testCase.inputSize << ", outputSize=" << testCase.outputSize << "}";
+    }
+
+    /**
+     * @brief Buffer geometries that violate the process() contract on the passthrough path
+     *        (input.size() must equal peekNextInputFrames(); output.size() must equal
+     *        outputFrames()). In passthrough peekNextInputFrames() returns
+     *        kDefaultOutputFrames, so 1024/1024 is the only valid pair and either sibling
+     *        shrunk to half triggers rejection.
+     */
+    std::vector<AudioRateConverterProcessRejectionTestCase> makeAudioRateConverterProcessRejectionTestCases() {
+        return {
+            AudioRateConverterProcessRejectionTestCase{
+                "WrongInputSize", kDefaultOutputFrames / 2, kDefaultOutputFrames},
+            AudioRateConverterProcessRejectionTestCase{
+                "WrongOutputSize", kDefaultOutputFrames, kDefaultOutputFrames / 2},
+        };
+    }
+}  // namespace
+
+class AudioRateConverterProcessRejectionTest
+    : public ::testing::TestWithParam<AudioRateConverterProcessRejectionTestCase> {};
+
+/**
+ * @brief process() reports failure when either span violates the geometry contract.
+ *
+ * Mismatched span sizes return false instead of corrupting the staging buffer or producing
+ * partial output - the caller treats false as a hard contract violation and propagates it
+ * up the pipeline rather than swallowing the discrepancy.
+ */
+TEST_P(AudioRateConverterProcessRejectionTest, ReportsFailure) {
+    const auto& testCase{GetParam()};
+    AudioRateConverter audioRateConverter{kBroadcastRateHz, kBroadcastRateHz, kDefaultOutputFrames};
+    std::vector<float> inputSamples(testCase.inputSize, 0.0F);
+    std::vector<float> outputSamples(testCase.outputSize, 0.0F);
+
+    EXPECT_FALSE(audioRateConverter.process(inputSamples, outputSamples));
+}
+
+INSTANTIATE_TEST_SUITE_P(OffendingSpan, AudioRateConverterProcessRejectionTest,
+                         ::testing::ValuesIn(makeAudioRateConverterProcessRejectionTestCases()),
+                         [](const ::testing::TestParamInfo<AudioRateConverterProcessRejectionTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/audio/tests/test_libsndfile_audio_source.cpp
+++ b/src/utils/audio/tests/test_libsndfile_audio_source.cpp
@@ -3,7 +3,7 @@
  * @brief Unit tests for the libsndfile-backed AudioSource factory.
  *
  * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
- * @date 05.05.2026
+ * @date 15.05.2026
  * @copyright GPL-3.0
  * @see https://github.com/IgrikXD/rpitx-ui
  * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
@@ -22,12 +22,10 @@
 #include <system_error>
 #include <vector>
 
+#include "captured_streams_mixin.h"
 #include "libsndfile_audio_source.h"
 
 namespace {
-    using ::testing::internal::CaptureStderr;
-    using ::testing::internal::GetCapturedStderr;
-
     /**
      * @brief CD-audio sample rate (44.1 kHz). Paired with stereo on the open-format case.
      */
@@ -104,47 +102,9 @@ namespace {
         }
     };
 
-    /**
-     * @brief Test-mixin that arms gtest's stderr capture in SetUp and exposes the captured
-     *        text via a lazy, cached accessor, releasing any unconsumed capture in TearDown.
-     *
-     * Parameterized by the gtest fixture base (`::testing::Test` for non-parametric tests,
-     * `::testing::TestWithParam<T>` for value-parametrized ones) so the same capture behaviour
-     * plugs into either kind of fixture without code duplication. SetUp arms unconditionally;
-     * the test body only pays the Get cost when it actually queries via capturedStderr().
-     * The accessor caches on first call - gtest's API permits exactly one Get per Capture,
-     * and the cache turns subsequent calls into a reference read instead of a double-Get
-     * crash. TearDown releases the stream when the body never consumed it, keeping the
-     * process-global capture state clean for the next test.
-     */
-    template <typename Base>
-    class CapturedStderrMixin : public Base {
-    protected:
-        void SetUp() override {
-            CaptureStderr();
-        }
-
-        void TearDown() override {
-            if (stderrConsumed_ == false) {
-                GetCapturedStderr();
-            }
-        }
-
-        const std::string& capturedStderr() {
-            if (stderrConsumed_ == false) {
-                cachedStderr_   = GetCapturedStderr();
-                stderrConsumed_ = true;
-            }
-            return cachedStderr_;
-        }
-
-    private:
-        std::string cachedStderr_;
-        bool stderrConsumed_{false};
-    };
 }  // namespace
 
-class MakeFileAudioSourceFailureTest : public CapturedStderrMixin<::testing::Test> {};
+class MakeFileAudioSourceFailureTest : public CapturedStreamsMixin<::testing::Test> {};
 
 /**
  * @brief makeFileAudioSource returns nullptr and emits a stderr diagnostic for a nonexistent path.

--- a/src/utils/audio/tests/test_libsndfile_audio_source.cpp
+++ b/src/utils/audio/tests/test_libsndfile_audio_source.cpp
@@ -1,0 +1,335 @@
+/**
+ * @file test_libsndfile_audio_source.cpp
+ * @brief Unit tests for the libsndfile-backed AudioSource factory.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 05.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+#include <sndfile.h>
+
+#include <cstddef>
+#include <filesystem>
+#include <ostream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "libsndfile_audio_source.h"
+
+namespace {
+    using ::testing::internal::CaptureStderr;
+    using ::testing::internal::GetCapturedStderr;
+
+    /**
+     * @brief CD-audio sample rate (44.1 kHz). Paired with stereo on the open-format case.
+     */
+    constexpr int kCdAudioRateHz{44'100};
+
+    /**
+     * @brief Broadcast sample rate (48 kHz). Default for the mono open-format case and
+     *        for every read / rewind / dispatcher fixture.
+     */
+    constexpr int kBroadcastRateHz{48'000};
+
+    /**
+     * @brief Default fixture-WAV frame count. 256 frames keeps the on-disk PCM_16 WAV
+     *        in the low-kilobyte range (~0.5 KiB mono, ~1 KiB stereo) - cheap enough to
+     *        write per test yet large enough to materialize a non-degenerate sample
+     *        buffer for both channel layouts.
+     */
+    constexpr int kDefaultFixtureFrames{256};
+
+    /**
+     * @brief Write a PCM_16 WAV fixture (mono or stereo) to a unique temp path.
+     *
+     * Each call writes a fresh file at `<temp_dir>/rpitx_test_<random>.wav` so parallel
+     * ctest workers do not clash on the same path. The sample content is a deterministic
+     * linear ramp in [0, 0.5] - low-amplitude, well within libsndfile's PCM_16 -> float
+     * range and adjacent-frame-distinct so a rewind comparison can detect any non-zero
+     * seek offset.
+     *
+     * @throws std::runtime_error On sf_open failure or short write.
+     */
+    [[nodiscard]] std::string writeTempWav(int channels, int sampleRate, int frames) {
+        SF_INFO info{};
+        info.channels   = channels;
+        info.samplerate = sampleRate;
+        info.format     = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+
+        std::random_device randomDevice;
+        const auto stem{std::to_string(randomDevice()) + "_" + std::to_string(randomDevice())};
+        const auto path{(std::filesystem::temp_directory_path() / ("rpitx_test_" + stem + ".wav")).string()};
+
+        SNDFILE* handle{sf_open(path.c_str(), SFM_WRITE, &info)};
+        if (handle == nullptr) {
+            throw std::runtime_error{std::string{"writeTempWav: sf_open failed: "} + sf_strerror(nullptr)};
+        }
+
+        std::vector<float> samples(static_cast<std::size_t>(frames) * static_cast<std::size_t>(channels));
+        for (std::size_t n{0}; n < static_cast<std::size_t>(frames); ++n) {
+            const float sample{static_cast<float>(n) / static_cast<float>(frames) * 0.5F};
+            for (int c{0}; c < channels; ++c) {
+                samples[n * static_cast<std::size_t>(channels) + static_cast<std::size_t>(c)] = sample;
+            }
+        }
+        const sf_count_t written{sf_writef_float(handle, samples.data(), frames)};
+        sf_close(handle);
+        if (written != frames) {
+            throw std::runtime_error{"writeTempWav: short write"};
+        }
+        return path;
+    }
+
+    /**
+     * @brief RAII guard that removes the file on destruction.
+     *
+     * Keeps ctest's temp directory clean across hundreds of unit-test runs instead of
+     * relying on the operating system's eventual GC of the temp tree.
+     */
+    struct TempFileGuard {
+        std::string path;
+        ~TempFileGuard() {
+            if (path.empty() == false) {
+                std::error_code ec;
+                std::filesystem::remove(path, ec);
+            }
+        }
+    };
+
+    /**
+     * @brief Test-mixin that arms gtest's stderr capture in SetUp and exposes the captured
+     *        text via a lazy, cached accessor, releasing any unconsumed capture in TearDown.
+     *
+     * Parameterized by the gtest fixture base (`::testing::Test` for non-parametric tests,
+     * `::testing::TestWithParam<T>` for value-parametrized ones) so the same capture behaviour
+     * plugs into either kind of fixture without code duplication. SetUp arms unconditionally;
+     * the test body only pays the Get cost when it actually queries via capturedStderr().
+     * The accessor caches on first call - gtest's API permits exactly one Get per Capture,
+     * and the cache turns subsequent calls into a reference read instead of a double-Get
+     * crash. TearDown releases the stream when the body never consumed it, keeping the
+     * process-global capture state clean for the next test.
+     */
+    template <typename Base>
+    class CapturedStderrMixin : public Base {
+    protected:
+        void SetUp() override {
+            CaptureStderr();
+        }
+
+        void TearDown() override {
+            if (stderrConsumed_ == false) {
+                GetCapturedStderr();
+            }
+        }
+
+        const std::string& capturedStderr() {
+            if (stderrConsumed_ == false) {
+                cachedStderr_   = GetCapturedStderr();
+                stderrConsumed_ = true;
+            }
+            return cachedStderr_;
+        }
+
+    private:
+        std::string cachedStderr_;
+        bool stderrConsumed_{false};
+    };
+}  // namespace
+
+class MakeFileAudioSourceFailureTest : public CapturedStderrMixin<::testing::Test> {};
+
+/**
+ * @brief makeFileAudioSource returns nullptr and emits a stderr diagnostic for a nonexistent path.
+ *
+ * The failure-path contract is two-fold: the factory surfaces the error through a nullptr
+ * return so callers can branch on a simple null check instead of a try/catch, and through
+ * a stderr diagnostic so a CLI launch failure is visible to the operator. Asserting that
+ * stderr is non-empty rather than checking its exact content keeps the test stable across
+ * libsndfile release notes - the surviving contract is "tells the user something went
+ * wrong," not the precise wording of sf_strerror.
+ */
+TEST_F(MakeFileAudioSourceFailureTest, ReturnsNullptrAndPrintsDiagnosticForNonexistentPath) {
+    const auto audioSource{makeFileAudioSource("/this/path/does/not/exist/at/all.wav")};
+
+    EXPECT_EQ(audioSource, nullptr);
+    EXPECT_FALSE(capturedStderr().empty());
+}
+
+namespace {
+    struct OpenFormatTestCase {
+        std::string_view name;
+        int channels;
+        int sampleRateHz;
+    };
+
+    /**
+     * @brief Render an open-format case as its name and the (channels, sampleRateHz) pair
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const OpenFormatTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {channels=" << testCase.channels << ", sampleRateHz=" << testCase.sampleRateHz << "}";
+    }
+
+    /**
+     * @brief Representative channel / rate pairs the file factory must open and report
+     *        correctly: a mono broadcast WAV and a stereo CD-rate WAV. Two cases cover
+     *        the two channel layouts the project's audio path uses in practice; the
+     *        broadcast / CD pairing is the same canonical pairing used by the
+     *        SoxrResampler and AudioRateConverter test suites.
+     */
+    std::vector<OpenFormatTestCase> makeOpenFormatTestCases() {
+        return {
+            OpenFormatTestCase{"MonoBroadcast", 1, kBroadcastRateHz},
+            OpenFormatTestCase{"StereoCd", 2, kCdAudioRateHz},
+        };
+    }
+}  // namespace
+
+class MakeFileAudioSourceOpenTest : public ::testing::TestWithParam<OpenFormatTestCase> {};
+
+/**
+ * @brief Opening a valid WAV exposes the per-case format plus the universal success invariants.
+ *
+ * Per-case half (channels, sampleRate) verifies the ctor wired SF_INFO through into
+ * AudioFormat for each input pair. Universal half (seekable() true, error() false,
+ * description() non-empty) holds for any regular-file backing produced by libsndfile and
+ * is therefore checked on both cases as a bundle rather than split into a parallel test.
+ * A regression that hardcoded a wrong channel count or sample rate trips exactly one of
+ * the two cases, isolating the misrouted axis; a universal-invariant regression (e.g.
+ * always-false seekable) trips both uniformly - still surfaced, but without per-case
+ * attribution.
+ */
+TEST_P(MakeFileAudioSourceOpenTest, ExposesFormatAndSuccessInvariantsForValidWav) {
+    const auto& testCase{GetParam()};
+    TempFileGuard guard{writeTempWav(testCase.channels, testCase.sampleRateHz, kDefaultFixtureFrames)};
+    const auto audioSource{makeFileAudioSource(guard.path)};
+    ASSERT_NE(audioSource, nullptr);
+
+    const auto audioFormat{audioSource->format()};
+
+    EXPECT_EQ(audioFormat.channels, testCase.channels);
+    EXPECT_EQ(audioFormat.sampleRate, testCase.sampleRateHz);
+    EXPECT_TRUE(audioSource->seekable());
+    EXPECT_FALSE(audioSource->error());
+    EXPECT_FALSE(audioSource->description().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(ChannelRatePairs, MakeFileAudioSourceOpenTest, ::testing::ValuesIn(makeOpenFormatTestCases()),
+                         [](const ::testing::TestParamInfo<OpenFormatTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+/**
+ * @brief read() fills the destination buffer with floats clamped to [-1, 1].
+ *
+ * Sizing the destination exactly to the fixture frame count lets the test assert a
+ * full-consume (samplesRead == destination.size()) before the range-check loop - without
+ * that, a buggy "always return 0" SUT would let the loop trivially pass against the
+ * default-initialized zeros and miss the regression. The fixture writes a [0, 0.5]
+ * linear ramp, well within the SUT's sanitize-and-clamp range, so a raw-int16 leak from
+ * a buggy format conversion would produce out-of-range values and trip the loop.
+ */
+TEST(MakeFileAudioSourceTest, ReadProducesNormalizedFloats) {
+    TempFileGuard guard{writeTempWav(1, kBroadcastRateHz, kDefaultFixtureFrames)};
+    const auto audioSource{makeFileAudioSource(guard.path)};
+    ASSERT_NE(audioSource, nullptr);
+    std::vector<float> destinationSamples(static_cast<std::size_t>(kDefaultFixtureFrames), 0.0F);
+
+    const auto samplesRead{audioSource->read(destinationSamples)};
+
+    EXPECT_EQ(samplesRead, destinationSamples.size());
+    for (float sample: destinationSamples) {
+        EXPECT_GE(sample, -1.0F);
+        EXPECT_LE(sample, 1.0F);
+    }
+}
+
+/**
+ * @brief read() throws std::invalid_argument on an empty destination span.
+ *
+ * The empty-span branch of the SUT contract surfaces a programmer error - a caller that
+ * forgot to size its buffer before calling read() - via throw rather than a sticky error
+ * flag, so the fault propagates loudly through the test harness instead of being masked
+ * under generic "source failed" telemetry. Exercising against a mono fixture isolates the
+ * empty branch from the channel-alignment branch (covered by
+ * ReadThrowsOnUnalignedDestinationSize).
+ */
+TEST(MakeFileAudioSourceTest, ReadThrowsOnEmptyDestination) {
+    TempFileGuard guard{writeTempWav(1, kBroadcastRateHz, kDefaultFixtureFrames)};
+    const auto audioSource{makeFileAudioSource(guard.path)};
+    ASSERT_NE(audioSource, nullptr);
+    std::vector<float> emptyDestination;
+
+    EXPECT_THROW(
+        { [[maybe_unused]] const std::size_t samplesRead{audioSource->read(emptyDestination)}; },
+        std::invalid_argument);
+}
+
+/**
+ * @brief read() throws std::invalid_argument when destination size is not a multiple of channels.
+ *
+ * The alignment branch of the SUT contract is exercised against a stereo fixture (channels=2)
+ * with a 7-element destination: 7 % 2 != 0 trips the rejection. An odd buffer size against
+ * a mono fixture would always satisfy size % 1 == 0 and miss this branch entirely - the
+ * stereo fixture is what makes the test discriminating.
+ */
+TEST(MakeFileAudioSourceTest, ReadThrowsOnUnalignedDestinationSize) {
+    TempFileGuard guard{writeTempWav(2, kBroadcastRateHz, kDefaultFixtureFrames)};
+    const auto audioSource{makeFileAudioSource(guard.path)};
+    ASSERT_NE(audioSource, nullptr);
+    constexpr std::size_t kUnalignedDestinationSize{7};
+    std::vector<float> unalignedDestination(kUnalignedDestinationSize, 0.0F);
+
+    EXPECT_THROW(
+        { [[maybe_unused]] const std::size_t samplesRead{audioSource->read(unalignedDestination)}; },
+        std::invalid_argument);
+}
+
+/**
+ * @brief rewind() restores the read position so a second pass matches the first byte-for-byte.
+ *
+ * Both passes read the same number of frames into separately-allocated buffers and the
+ * comparison is via vector equality. Byte-for-byte equality is a stricter contract than
+ * "rewind seeked somewhere earlier" - it catches a regression where the seek lands at a
+ * non-zero offset (e.g. header skip miscounted) by failing on the very first differing
+ * sample. The fixture's linear-ramp content guarantees adjacent frames differ, so any
+ * non-zero seek offset produces an immediate mismatch instead of accidentally aliasing
+ * into the same data.
+ */
+TEST(MakeFileAudioSourceTest, RewindRestartsReadFromTheBeginning) {
+    TempFileGuard guard{writeTempWav(1, kBroadcastRateHz, kDefaultFixtureFrames)};
+    const auto audioSource{makeFileAudioSource(guard.path)};
+    ASSERT_NE(audioSource, nullptr);
+    std::vector<float> firstPassSamples(static_cast<std::size_t>(kDefaultFixtureFrames), 0.0F);
+    std::vector<float> secondPassSamples(static_cast<std::size_t>(kDefaultFixtureFrames), 0.0F);
+
+    EXPECT_EQ(audioSource->read(firstPassSamples), firstPassSamples.size());
+    EXPECT_TRUE(audioSource->rewind());
+    EXPECT_EQ(audioSource->read(secondPassSamples), secondPassSamples.size());
+    EXPECT_EQ(firstPassSamples, secondPassSamples);
+}
+
+/**
+ * @brief makeAudioSource with useStdin=false routes to makeFileAudioSource and produces a usable source.
+ *
+ * The dispatcher's false-branch is a thin tail call into the file factory, so the smallest
+ * stable signal that the dispatch wiring is intact is a non-null return on the same input
+ * makeFileAudioSource would accept. Re-asserting the full format / metadata contract here
+ * would duplicate ExposesFormatAndSuccessInvariantsForValidWav; the dispatcher is only
+ * responsible for routing, not for re-validating libsndfile's output.
+ */
+TEST(MakeAudioSourceTest, DispatchesToFileFactoryWhenStdinFlagFalse) {
+    TempFileGuard guard{writeTempWav(1, kBroadcastRateHz, kDefaultFixtureFrames)};
+
+    const auto audioSource{makeAudioSource(false, guard.path)};
+
+    EXPECT_NE(audioSource, nullptr);
+}

--- a/src/utils/audio/tests/test_libsndfile_audio_source.cpp
+++ b/src/utils/audio/tests/test_libsndfile_audio_source.cpp
@@ -63,8 +63,9 @@ namespace {
         info.format     = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
 
         std::random_device randomDevice;
-        const auto stem{std::to_string(randomDevice()) + "_" + std::to_string(randomDevice())};
-        const auto path{(std::filesystem::temp_directory_path() / ("rpitx_test_" + stem + ".wav")).string()};
+        const auto path{
+            (std::filesystem::temp_directory_path() / ("rpitx_test_" + std::to_string(randomDevice()) + ".wav"))
+                .string()};
 
         SNDFILE* handle{sf_open(path.c_str(), SFM_WRITE, &info)};
         if (handle == nullptr) {

--- a/src/utils/audio/tests/test_soxr_resampler.cpp
+++ b/src/utils/audio/tests/test_soxr_resampler.cpp
@@ -1,0 +1,354 @@
+/**
+ * @file test_soxr_resampler.cpp
+ * @brief Unit tests for the SoxrResampler RAII wrapper.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 12.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "soxr_resampler.h"
+
+namespace {
+    /**
+     * @brief CD-audio source rate (44.1 kHz). Default upsampling source for the
+     *        process()/clear()/move tests and several acceptance cases.
+     */
+    constexpr int kCdAudioRateHz{44'100};
+
+    /**
+     * @brief Broadcast target rate (48 kHz). Paired with kCdAudioRateHz on the
+     *        upsampling path and reused as both source and target on the
+     *        identity-ratio acceptance case.
+     */
+    constexpr int kBroadcastRateHz{48'000};
+
+    /**
+     * @brief Lower extreme rate used by the extreme-upsample acceptance case
+     *        (8 kHz -> 192 kHz). Exercises a wide rate ratio that pushes the
+     *        libsoxr filter dimensions toward their upper bound.
+     */
+    constexpr int kNarrowRateHz{8'000};
+
+    /**
+     * @brief Upper extreme rate paired with kNarrowRateHz on the same case.
+     */
+    constexpr int kVeryWideRateHz{192'000};
+
+    /**
+     * @brief Default per-block input size used across the EOS-flush, clear, and move tests at
+     *        the canonical CD -> Broadcast rate pair. Matches the per-block sizes
+     *        pinfm/pifmrds feed in production.
+     */
+    constexpr std::size_t kBlockInputFrames{1024};
+
+    /**
+     * @brief Output buffer size paired with kBlockInputFrames at the 44.1 -> 48 kHz ratio.
+     *        ~2x the expected output count (1024 * 48000 / 44100 ~= 1114) so libsoxr halts
+     *        on input exhaustion rather than the output cap.
+     */
+    constexpr std::size_t kBlockOutputFrames{2048};
+}  // namespace
+
+/**
+ * @brief process() consumes the full input span when the output buffer is generously sized.
+ *
+ * With 2048 input frames at the 44.1 -> 48 kHz ratio the expected output is ~2230 frames;
+ * the 4096-frame staging buffer is roughly 2x that, so libsoxr halts on input exhaustion
+ * (inputConsumed == in.size()) rather than the output cap. The combined assertions verify
+ * the full-consume invariant, that the call returned a present optional, and that
+ * outputProduced is non-zero (catches a "no-op" implementation) yet stays within the
+ * supplied output buffer.
+ */
+TEST(SoxrResamplerTest, ProcessConsumesFullInputWhenStagingOversized) {
+    SoxrResampler soxrResampler{kCdAudioRateHz, kBroadcastRateHz};
+    constexpr std::size_t kInputFrames{2048};
+    constexpr std::size_t kOversizedOutputFrames{4096};
+    std::vector<float> inputSamples(kInputFrames, 0.5F);
+    std::vector<float> outputSamples(kOversizedOutputFrames, 0.0F);
+
+    const auto result{soxrResampler.process(inputSamples, outputSamples)};
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().inputConsumed, inputSamples.size());
+    EXPECT_GT(result.value().outputProduced, 0U);
+    EXPECT_LE(result.value().outputProduced, outputSamples.size());
+}
+
+/**
+ * @brief Empty input span as the EOS flush form succeeds and reports zero input consumed.
+ *
+ * Priming the resampler with a non-empty block first populates the filter delay line so
+ * the subsequent empty-input call exercises libsoxr's documented end-of-stream flush form.
+ * The call must succeed (non-nullopt) and report inputConsumed == 0 because no input was
+ * supplied. outputProduced is intentionally not asserted - the residual tail length depends
+ * on internal libsoxr state and is not a stable contract.
+ */
+TEST(SoxrResamplerTest, EmptyInputFlushReportsZeroConsumed) {
+    SoxrResampler soxrResampler{kCdAudioRateHz, kBroadcastRateHz};
+    std::vector<float> primingInput(kBlockInputFrames, 0.5F);
+    std::vector<float> primingOutput(kBlockOutputFrames, 0.0F);
+    ASSERT_TRUE(soxrResampler.process(primingInput, primingOutput).has_value());
+
+    constexpr std::size_t kFlushOutputFrames{512};
+    std::vector<float> flushOutput(kFlushOutputFrames, 0.0F);
+    const auto result{soxrResampler.process({}, flushOutput)};
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().inputConsumed, 0U);
+}
+
+/**
+ * @brief After clear(), the resampler produces the same first-call output count as a fresh instance.
+ *
+ * Builds two resamplers with identical rates. The reference instance processes one block from
+ * a cold start, so its outputProduced reflects libsoxr's warmup-pass output (smaller than
+ * steady-state because the filter delay line has not yet been populated). The subject
+ * instance is primed with one block (filling the delay line), then clear()ed, then processes
+ * the same input. A buggy no-op clear() would leave the delay line populated and the second
+ * pass would emit the steady-state (larger) output count; a working clear() restores the
+ * delay line to its empty state so the post-clear call matches the reference warmup pass
+ * exactly. Comparing outputProduced is the smallest stable signal that the internal state
+ * was actually reset - per-sample buffer equality would be a stricter contract but relies
+ * on libsoxr's float output being bit-stable across platforms, which is documented behavior
+ * but not contractually guaranteed.
+ */
+TEST(SoxrResamplerTest, ClearProducesFreshInstanceOutputCount) {
+    std::vector<float> inputSamples(kBlockInputFrames, 0.5F);
+
+    SoxrResampler freshResampler{kCdAudioRateHz, kBroadcastRateHz};
+    std::vector<float> freshOutput(kBlockOutputFrames, 0.0F);
+    const auto freshResult{freshResampler.process(inputSamples, freshOutput)};
+    ASSERT_TRUE(freshResult.has_value());
+
+    SoxrResampler primedAndClearedResampler{kCdAudioRateHz, kBroadcastRateHz};
+    std::vector<float> primingOutput(kBlockOutputFrames, 0.0F);
+    ASSERT_TRUE(primedAndClearedResampler.process(inputSamples, primingOutput).has_value());
+    primedAndClearedResampler.clear();
+    std::vector<float> postClearOutput(kBlockOutputFrames, 0.0F);
+    const auto postClearResult{primedAndClearedResampler.process(inputSamples, postClearOutput)};
+    ASSERT_TRUE(postClearResult.has_value());
+
+    EXPECT_EQ(postClearResult.value().outputProduced, freshResult.value().outputProduced);
+}
+
+/**
+ * @brief Move-constructed instance retains a fully functional libsoxr handle.
+ *
+ * The Impl pointer transfers ownership from the donor to the taker; the donor is left in a
+ * valid-but-empty state that must remain safely destructible at scope exit (verified
+ * implicitly by the test completing without crash). The taker then processes a non-trivial
+ * input block - a present optional from process() is the smallest signal that the underlying
+ * soxr_t survived the move and the resampler is still wired through to libsoxr.
+ */
+TEST(SoxrResamplerTest, MoveConstructedInstanceProcessesSuccessfully) {
+    SoxrResampler donor{kCdAudioRateHz, kBroadcastRateHz};
+    SoxrResampler taker{std::move(donor)};
+    std::vector<float> inputSamples(kBlockInputFrames, 0.5F);
+    std::vector<float> outputSamples(kBlockOutputFrames, 0.0F);
+
+    EXPECT_TRUE(taker.process(inputSamples, outputSamples).has_value());
+}
+
+/**
+ * @brief Move-assigned instance retains a fully functional libsoxr handle and adopts donor's rates.
+ *
+ * The Impl pointer transfers from donor to taker, replacing taker's prior unique_ptr. The
+ * taker is intentionally constructed with the reversed rate pair so the assignment is
+ * non-trivial - it must release the old handle and adopt donor's. The strong-form contract
+ * is that taker's post-assignment process() emits the same outputProduced as a cold-start
+ * reference resampler built at donor's rates running on the same input - a buggy operator=
+ * that left taker holding its original 48 -> 44.1 kHz handle would emit the downsampling
+ * output count instead and fail the comparison. Reference-relative comparison side-steps
+ * libsoxr's cold-start filter warmup, which would make an absolute frame-count assertion
+ * (e.g. outputProduced > inputSamples.size()) unreliable at Medium quality because the
+ * warmup deficit can erase the upsampling gain on a single 1024-sample block.
+ */
+TEST(SoxrResamplerTest, MoveAssignedInstanceProcessesSuccessfully) {
+    std::vector<float> inputSamples(kBlockInputFrames, 0.5F);
+
+    SoxrResampler referenceResampler{kCdAudioRateHz, kBroadcastRateHz};
+    std::vector<float> referenceOutput(kBlockOutputFrames, 0.0F);
+    const auto referenceResult{referenceResampler.process(inputSamples, referenceOutput)};
+    ASSERT_TRUE(referenceResult.has_value());
+
+    SoxrResampler donor{kCdAudioRateHz, kBroadcastRateHz};
+    SoxrResampler taker{kBroadcastRateHz, kCdAudioRateHz};
+    taker = std::move(donor);
+    std::vector<float> takerOutput(kBlockOutputFrames, 0.0F);
+    const auto takerResult{taker.process(inputSamples, takerOutput)};
+    ASSERT_TRUE(takerResult.has_value());
+
+    EXPECT_EQ(takerResult.value().outputProduced, referenceResult.value().outputProduced);
+}
+
+namespace {
+    struct CtorRateRejectionTestCase {
+        std::string_view name;
+        int sourceRateHz;
+        int targetRateHz;
+    };
+
+    /**
+     * @brief Render a ctor rate-rejection case as its name plus the offending rate pair for
+     *        gtest listings and failure messages.
+     */
+    void PrintTo(const CtorRateRejectionTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {sourceRateHz=" << testCase.sourceRateHz << ", targetRateHz=" << testCase.targetRateHz
+            << "}";
+    }
+
+    /**
+     * @brief Constructor rate pairs that violate the (sourceRateHz > 0, targetRateHz > 0)
+     *        precondition. One named case per distinct violation channel.
+     */
+    std::vector<CtorRateRejectionTestCase> makeCtorRateRejectionTestCases() {
+        return {
+            CtorRateRejectionTestCase{"SourceRateZero", 0, kBroadcastRateHz},
+            CtorRateRejectionTestCase{"SourceRateNegative", -1, kBroadcastRateHz},
+            CtorRateRejectionTestCase{"TargetRateZero", kBroadcastRateHz, 0},
+            CtorRateRejectionTestCase{"TargetRateNegative", kBroadcastRateHz, -1},
+        };
+    }
+}  // namespace
+
+class SoxrResamplerCtorRejectionTest : public ::testing::TestWithParam<CtorRateRejectionTestCase> {};
+
+/**
+ * @brief Every non-positive constructor rate raises std::invalid_argument.
+ */
+TEST_P(SoxrResamplerCtorRejectionTest, ThrowsInvalidArgument) {
+    const auto& testCase{GetParam()};
+
+    EXPECT_THROW(SoxrResampler(testCase.sourceRateHz, testCase.targetRateHz), std::invalid_argument);
+}
+
+INSTANTIATE_TEST_SUITE_P(NonPositiveParameter, SoxrResamplerCtorRejectionTest,
+                         ::testing::ValuesIn(makeCtorRateRejectionTestCases()),
+                         [](const ::testing::TestParamInfo<CtorRateRejectionTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct CtorRatePairTestCase {
+        std::string_view name;
+        int sourceRateHz;
+        int targetRateHz;
+    };
+
+    /**
+     * @brief Render a ctor rate-pair case as its name plus the rate pair for gtest listings
+     *        and failure messages.
+     */
+    void PrintTo(const CtorRatePairTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {sourceRateHz=" << testCase.sourceRateHz << ", targetRateHz=" << testCase.targetRateHz
+            << "}";
+    }
+
+    /**
+     * @brief Representative rate-ratio shapes at the default Medium quality. Upsample and
+     *        Downsample swap source/target around the canonical CD/Broadcast pair; Identity
+     *        exercises the equal-rate configuration; ExtremeUpsample stresses a wide rate
+     *        ratio that pushes libsoxr's filter dimensions toward their upper bound.
+     */
+    std::vector<CtorRatePairTestCase> makeCtorRatePairTestCases() {
+        return {
+            CtorRatePairTestCase{"Upsample", kCdAudioRateHz, kBroadcastRateHz},
+            CtorRatePairTestCase{"Downsample", kBroadcastRateHz, kCdAudioRateHz},
+            CtorRatePairTestCase{"Identity", kBroadcastRateHz, kBroadcastRateHz},
+            CtorRatePairTestCase{"ExtremeUpsample", kNarrowRateHz, kVeryWideRateHz},
+        };
+    }
+}  // namespace
+
+class SoxrResamplerCtorRatePairTest : public ::testing::TestWithParam<CtorRatePairTestCase> {};
+
+/**
+ * @brief Every representative rate-ratio shape constructs without throwing at the default quality.
+ */
+TEST_P(SoxrResamplerCtorRatePairTest, ConstructsWithoutThrowing) {
+    const auto& testCase{GetParam()};
+
+    EXPECT_NO_THROW(SoxrResampler(testCase.sourceRateHz, testCase.targetRateHz));
+}
+
+INSTANTIATE_TEST_SUITE_P(RatioShapes, SoxrResamplerCtorRatePairTest, ::testing::ValuesIn(makeCtorRatePairTestCases()),
+                         [](const ::testing::TestParamInfo<CtorRatePairTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct CtorQualityTestCase {
+        std::string_view name;
+        SoxrResampler::Quality quality;
+    };
+
+    /**
+     * @brief Map a Quality preset to its enumerator name for human-readable failure messages.
+     */
+    [[nodiscard]] constexpr std::string_view qualityName(SoxrResampler::Quality quality) noexcept {
+        switch (quality) {
+            case SoxrResampler::Quality::Quick:
+                return "Quick";
+            case SoxrResampler::Quality::Low:
+                return "Low";
+            case SoxrResampler::Quality::Medium:
+                return "Medium";
+            case SoxrResampler::Quality::High:
+                return "High";
+            case SoxrResampler::Quality::VeryHigh:
+                return "VeryHigh";
+        }
+        return "Unknown";
+    }
+
+    /**
+     * @brief Render a ctor quality case as its name plus the resolved preset name for gtest
+     *        listings and failure messages.
+     */
+    void PrintTo(const CtorQualityTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {quality=" << qualityName(testCase.quality) << "}";
+    }
+
+    /**
+     * @brief Every quality preset other than Medium at the canonical upsample rate pair.
+     *        Medium is already covered by the RatioShapes/Upsample case, so we skip it here
+     *        to avoid the redundant pair.
+     */
+    std::vector<CtorQualityTestCase> makeCtorQualityTestCases() {
+        return {
+            CtorQualityTestCase{"Quick", SoxrResampler::Quality::Quick},
+            CtorQualityTestCase{"Low", SoxrResampler::Quality::Low},
+            CtorQualityTestCase{"High", SoxrResampler::Quality::High},
+            CtorQualityTestCase{"VeryHigh", SoxrResampler::Quality::VeryHigh},
+        };
+    }
+}  // namespace
+
+class SoxrResamplerCtorQualityTest : public ::testing::TestWithParam<CtorQualityTestCase> {};
+
+/**
+ * @brief Every non-default quality preset constructs without throwing at the upsample rate pair.
+ */
+TEST_P(SoxrResamplerCtorQualityTest, ConstructsWithoutThrowing) {
+    const auto& testCase{GetParam()};
+
+    EXPECT_NO_THROW(SoxrResampler(kCdAudioRateHz, kBroadcastRateHz, testCase.quality));
+}
+
+INSTANTIATE_TEST_SUITE_P(AllPresets, SoxrResamplerCtorQualityTest, ::testing::ValuesIn(makeCtorQualityTestCases()),
+                         [](const ::testing::TestParamInfo<CtorQualityTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/audio/tests/test_soxr_resampler.cpp
+++ b/src/utils/audio/tests/test_soxr_resampler.cpp
@@ -147,11 +147,10 @@ TEST(SoxrResamplerTest, ClearProducesFreshInstanceOutputCount) {
 /**
  * @brief Move-constructed instance retains a fully functional libsoxr handle.
  *
- * The Impl pointer transfers ownership from the donor to the taker; the donor is left in a
- * valid-but-empty state that must remain safely destructible at scope exit (verified
- * implicitly by the test completing without crash). The taker then processes a non-trivial
- * input block - a present optional from process() is the smallest signal that the underlying
- * soxr_t survived the move and the resampler is still wired through to libsoxr.
+ * After the move the donor must remain safely destructible at scope exit (verified implicitly
+ * by the test completing without crash) and the taker must carry the working handle. A present
+ * optional from process() is the smallest signal that the underlying soxr_t survived the move
+ * and the resampler is still wired through to libsoxr.
  */
 TEST(SoxrResamplerTest, MoveConstructedInstanceProcessesSuccessfully) {
     SoxrResampler donor{kCdAudioRateHz, kBroadcastRateHz};
@@ -165,8 +164,7 @@ TEST(SoxrResamplerTest, MoveConstructedInstanceProcessesSuccessfully) {
 /**
  * @brief Move-assigned instance retains a fully functional libsoxr handle and adopts donor's rates.
  *
- * The Impl pointer transfers from donor to taker, replacing taker's prior unique_ptr. The
- * taker is intentionally constructed with the reversed rate pair so the assignment is
+ * The taker is intentionally constructed with the reversed rate pair so the assignment is
  * non-trivial - it must release the old handle and adopt donor's. The strong-form contract
  * is that taker's post-assignment process() emits the same outputProduced as a cold-start
  * reference resampler built at donor's rates running on the same input - a buggy operator=

--- a/src/utils/cli/CMakeLists.txt
+++ b/src/utils/cli/CMakeLists.txt
@@ -20,3 +20,7 @@ add_library(rpitx_cli_utils STATIC
 )
 target_include_directories(rpitx_cli_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpitx_cli_utils PUBLIC CLI11::CLI11)
+
+if(ENABLE_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/src/utils/cli/CMakeLists.txt
+++ b/src/utils/cli/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 29.04.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.

--- a/src/utils/cli/tests/CMakeLists.txt
+++ b/src/utils/cli/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 05.05.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
@@ -16,6 +16,7 @@ add_executable(rpitx_cli_utils_tests
 target_link_libraries(rpitx_cli_utils_tests
     PRIVATE
         rpitx_cli_utils
+        rpitx_common_test_utils
         GTest::gtest
         GTest::gtest_main
 )

--- a/src/utils/cli/tests/CMakeLists.txt
+++ b/src/utils/cli/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 05.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Unit tests for the shared CLI parsing utility library
+# ----------------------------------------------------------
+add_executable(rpitx_cli_utils_tests
+    test_parse_frequency.cpp
+    test_parse_cli_app.cpp
+    test_validators.cpp
+)
+
+target_link_libraries(rpitx_cli_utils_tests
+    PRIVATE
+        rpitx_cli_utils
+        GTest::gtest
+        GTest::gtest_main
+)
+
+gtest_discover_tests(rpitx_cli_utils_tests
+    PROPERTIES LABELS "unit;cli"
+)

--- a/src/utils/cli/tests/test_parse_cli_app.cpp
+++ b/src/utils/cli/tests/test_parse_cli_app.cpp
@@ -3,7 +3,7 @@
  * @brief Unit tests for rpitx::cli::parseCliApp and assignFrequencyHz.
  *
  * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
- * @date 11.05.2026
+ * @date 15.05.2026
  * @copyright GPL-3.0
  * @see https://github.com/IgrikXD/rpitx-ui
  * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
@@ -17,71 +17,12 @@
 #include <string_view>
 #include <vector>
 
+#include "captured_streams_mixin.h"
 #include "cli_common.h"
 #include "cli_parse_result.h"
 
 namespace {
     using rpitx::cli::ParseResult;
-    using ::testing::internal::CaptureStderr;
-    using ::testing::internal::CaptureStdout;
-    using ::testing::internal::GetCapturedStderr;
-    using ::testing::internal::GetCapturedStdout;
-
-    /**
-     * @brief Test-mixin that arms gtest's stdout/stderr capturers in SetUp and exposes
-     *        the captured text via lazy, cached accessors, releasing any unconsumed
-     *        capture in TearDown.
-     *
-     * Parameterized by the gtest fixture base (`::testing::Test` for non-parametric
-     * tests, `::testing::TestWithParam<T>` for value-parametrized ones) so the same
-     * capture behaviour plugs into either kind of fixture without code duplication.
-     * SetUp arms both captures unconditionally; the test body only pays the Get cost
-     * for the streams it actually queries via capturedStdout() / capturedStderr().
-     * The accessors cache on first call - gtest's API permits exactly one Get per
-     * Capture, and the cache turns subsequent calls into a reference read instead of
-     * a double-Get crash. TearDown releases any stream the body never consumed,
-     * keeping the process-global capture state clean for the next test even when a
-     * test bails out mid-body before reaching its stream assertions.
-     */
-    template <typename Base>
-    class CapturedStreamsMixin : public Base {
-    protected:
-        void SetUp() override {
-            CaptureStdout();
-            CaptureStderr();
-        }
-
-        void TearDown() override {
-            if (stdoutConsumed_ == false) {
-                GetCapturedStdout();
-            }
-            if (stderrConsumed_ == false) {
-                GetCapturedStderr();
-            }
-        }
-
-        const std::string& capturedStdout() {
-            if (stdoutConsumed_ == false) {
-                cachedStdout_   = GetCapturedStdout();
-                stdoutConsumed_ = true;
-            }
-            return cachedStdout_;
-        }
-
-        const std::string& capturedStderr() {
-            if (stderrConsumed_ == false) {
-                cachedStderr_   = GetCapturedStderr();
-                stderrConsumed_ = true;
-            }
-            return cachedStderr_;
-        }
-
-    private:
-        std::string cachedStdout_;
-        std::string cachedStderr_;
-        bool stdoutConsumed_{false};
-        bool stderrConsumed_{false};
-    };
 
     /**
      * @brief Drive parseCliApp with an inline argv list, owning the backing string storage internally.

--- a/src/utils/cli/tests/test_parse_cli_app.cpp
+++ b/src/utils/cli/tests/test_parse_cli_app.cpp
@@ -1,0 +1,305 @@
+/**
+ * @file test_parse_cli_app.cpp
+ * @brief Unit tests for rpitx::cli::parseCliApp and assignFrequencyHz.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 11.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cli_common.h"
+#include "cli_parse_result.h"
+
+namespace {
+    using rpitx::cli::ParseResult;
+    using ::testing::internal::CaptureStderr;
+    using ::testing::internal::CaptureStdout;
+    using ::testing::internal::GetCapturedStderr;
+    using ::testing::internal::GetCapturedStdout;
+
+    /**
+     * @brief Test-mixin that arms gtest's stdout/stderr capturers in SetUp and exposes
+     *        the captured text via lazy, cached accessors, releasing any unconsumed
+     *        capture in TearDown.
+     *
+     * Parameterized by the gtest fixture base (`::testing::Test` for non-parametric
+     * tests, `::testing::TestWithParam<T>` for value-parametrized ones) so the same
+     * capture behaviour plugs into either kind of fixture without code duplication.
+     * SetUp arms both captures unconditionally; the test body only pays the Get cost
+     * for the streams it actually queries via capturedStdout() / capturedStderr().
+     * The accessors cache on first call - gtest's API permits exactly one Get per
+     * Capture, and the cache turns subsequent calls into a reference read instead of
+     * a double-Get crash. TearDown releases any stream the body never consumed,
+     * keeping the process-global capture state clean for the next test even when a
+     * test bails out mid-body before reaching its stream assertions.
+     */
+    template <typename Base>
+    class CapturedStreamsMixin : public Base {
+    protected:
+        void SetUp() override {
+            CaptureStdout();
+            CaptureStderr();
+        }
+
+        void TearDown() override {
+            if (stdoutConsumed_ == false) {
+                GetCapturedStdout();
+            }
+            if (stderrConsumed_ == false) {
+                GetCapturedStderr();
+            }
+        }
+
+        const std::string& capturedStdout() {
+            if (stdoutConsumed_ == false) {
+                cachedStdout_   = GetCapturedStdout();
+                stdoutConsumed_ = true;
+            }
+            return cachedStdout_;
+        }
+
+        const std::string& capturedStderr() {
+            if (stderrConsumed_ == false) {
+                cachedStderr_   = GetCapturedStderr();
+                stderrConsumed_ = true;
+            }
+            return cachedStderr_;
+        }
+
+    private:
+        std::string cachedStdout_;
+        std::string cachedStderr_;
+        bool stdoutConsumed_{false};
+        bool stderrConsumed_{false};
+    };
+
+    /**
+     * @brief Drive parseCliApp with an inline argv list, owning the backing string storage internally.
+     *
+     * CLI11's parse() expects the canonical `char* argv[]` contract, so the underlying
+     * std::string storage must outlive the parse call. Wrapping that lifetime here keeps
+     * each test body a single call instead of three coupled lines (storage vector, char*
+     * projection, static_cast<int> for argc).
+     */
+    ParseResult parseArgs(CLI::App& app, std::vector<std::string> argStorage) {
+        std::vector<char*> argv;
+        argv.reserve(argStorage.size());
+        for (auto& arg: argStorage) {
+            argv.push_back(arg.data());
+        }
+        return rpitx::cli::parseCliApp(app, static_cast<int>(argv.size()), argv.data());
+    }
+}  // namespace
+
+class ParseCliAppTest : public CapturedStreamsMixin<::testing::Test> {};
+
+/**
+ * @brief Successful parse populates the registered option and stays silent on both streams.
+ *
+ * Feeds `--value 42` through CLI11 with a single int option bound, then asserts both the
+ * return code and the bound value to catch a regression where parseCliApp's success
+ * branch fails to actually invoke app.parse() - it is CLI11 (not the wrapper) that writes
+ * into the bound variable, so a wrapper that returned Ok without calling parse would still
+ * pass a return-code-only check. Both streams must stay empty on the success path; any
+ * leak indicates the wrapper printed help or a diagnostic out-of-contract.
+ */
+TEST_F(ParseCliAppTest, SuccessPopulatesOptionAndProducesNoOutput) {
+    CLI::App app{"test"};
+    int boundValue{0};
+    app.add_option("--value", boundValue, "");
+
+    const ParseResult result{parseArgs(app, {"prog", "--value", "42"})};
+
+    EXPECT_EQ(result, ParseResult::Ok);
+    EXPECT_EQ(boundValue, 42);
+    EXPECT_TRUE(capturedStderr().empty());
+    EXPECT_TRUE(capturedStdout().empty());
+}
+
+/**
+ * @brief An unknown flag routes the diagnostic and the help banner to stderr, leaving stdout untouched.
+ *
+ * Project contract for migrated binaries: parse errors emit `[ERROR] ...` followed by the
+ * help banner on stderr, so callers that pipe stdout into another tool stay clean even on
+ * failure. Asserting the `[ERROR]` prefix, the `Usage:` marker of CLI11's default help
+ * formatter, and stdout emptiness pins down all three pieces of the contract - a
+ * regression that mistakenly routed help to stdout, or dropped either half of the stderr
+ * payload, would slip past a return-code-only check.
+ */
+TEST_F(ParseCliAppTest, UnknownFlagRoutesErrorAndHelpToStderr) {
+    CLI::App app{"test"};
+
+    const ParseResult result{parseArgs(app, {"prog", "--no-such-flag"})};
+
+    EXPECT_EQ(result, ParseResult::Error);
+    EXPECT_NE(capturedStderr().find("[ERROR]"), std::string::npos);
+    EXPECT_NE(capturedStderr().find("Usage:"), std::string::npos);
+    EXPECT_TRUE(capturedStdout().empty());
+}
+
+namespace {
+    struct HelpFlagTestCase {
+        std::string_view name;
+        std::string_view flag;
+    };
+
+    /**
+     * @brief Render a HelpFlagTestCase as its name plus the CLI flag literal for gtest listings.
+     */
+    void PrintTo(const HelpFlagTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {flag=\"" << testCase.flag << "\"}";
+    }
+
+    /**
+     * @brief Both spellings of the help flag accepted by CLI11: GNU long form and POSIX short form.
+     */
+    std::vector<HelpFlagTestCase> makeHelpFlagTestCases() {
+        return {
+            HelpFlagTestCase{"LongForm", "--help"},
+            HelpFlagTestCase{"ShortForm", "-h"},
+        };
+    }
+}  // namespace
+
+class ParseCliAppHelpFlagTest : public CapturedStreamsMixin<::testing::TestWithParam<HelpFlagTestCase>> {};
+
+/**
+ * @brief Either spelling of the help flag returns ParseResult::Help and routes the banner to stdout.
+ *
+ * The project contract distinguishes help (clean exit, banner on stdout for piping) from
+ * errors (banner on stderr). Asserting that stderr stays empty and that stdout contains
+ * the `Usage:` marker of CLI11's default help formatter pins down both halves of the
+ * stream-routing contract; together with UnknownFlagRoutesErrorAndHelpToStderr the two
+ * tests cover both CLI11 exception paths.
+ */
+TEST_P(ParseCliAppHelpFlagTest, RoutesBannerToStdoutAndReturnsHelp) {
+    const auto& testCase{GetParam()};
+    CLI::App app{"test"};
+
+    const ParseResult result{parseArgs(app, {"prog", std::string{testCase.flag}})};
+
+    EXPECT_EQ(result, ParseResult::Help);
+    EXPECT_NE(capturedStdout().find("Usage:"), std::string::npos);
+    EXPECT_TRUE(capturedStderr().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(SpellingMatrix, ParseCliAppHelpFlagTest, ::testing::ValuesIn(makeHelpFlagTestCases()),
+                         [](const ::testing::TestParamInfo<HelpFlagTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+class AssignFrequencyHzTest : public CapturedStreamsMixin<::testing::Test> {};
+
+/**
+ * @brief Successful conversion writes the parsed Hz to the out variable and stays silent on both streams.
+ *
+ * "100e6" is the canonical megahertz-range input that exercises the scientific-notation
+ * branch of parseFrequencyHz; checking the exact 100_000_000 result distinguishes correct
+ * integer-Hz resolution from any silent truncation. Asserting both streams stay empty
+ * confirms the wrapper emits neither its diagnostic prefix nor any incidental stdout
+ * chatter on the success path.
+ */
+TEST_F(AssignFrequencyHzTest, SuccessAssignsParsedHzAndStaysSilent) {
+    std::uint64_t parsedHz{0};
+
+    const ParseResult result{rpitx::cli::assignFrequencyHz("100e6", parsedHz)};
+
+    EXPECT_EQ(result, ParseResult::Ok);
+    EXPECT_EQ(parsedHz, 100'000'000ULL);
+    EXPECT_TRUE(capturedStderr().empty());
+    EXPECT_TRUE(capturedStdout().empty());
+}
+
+/**
+ * @brief On rejection the stderr diagnostic contains both the fixed "[ERROR] Invalid --freq" prefix
+ *        and the original input echoed in single quotes, while stdout stays clean.
+ *
+ * The diagnostic format is the user-visible contract migrated binaries rely on for their
+ * error UX: splitting the check into two independent substring assertions catches a
+ * regression in either half (e.g. the prefix typo'd, or the original input dropped from
+ * the message). The Error-return and out-variable-preservation invariants are exercised
+ * across the full input matrix by AssignFrequencyHzRejectionTest; the stdout-empty check
+ * here guards against a regression where the failure path leaks any output to the
+ * success-side stream.
+ */
+TEST_F(AssignFrequencyHzTest, FailureDiagnosticContainsErrorPrefixAndOriginalInput) {
+    std::uint64_t parsedHz{0};
+
+    const ParseResult result{rpitx::cli::assignFrequencyHz("nope", parsedHz)};
+
+    EXPECT_EQ(result, ParseResult::Error);
+    EXPECT_NE(capturedStderr().find("[ERROR] Invalid --freq"), std::string::npos);
+    EXPECT_NE(capturedStderr().find("'nope'"), std::string::npos);
+    EXPECT_TRUE(capturedStdout().empty());
+}
+
+namespace {
+    struct AssignFrequencyHzRejectionTestCase {
+        std::string_view name;
+        std::string_view input;
+    };
+
+    /**
+     * @brief Render an AssignFrequencyHzRejectionTestCase as its name plus the rejected input
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const AssignFrequencyHzRejectionTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\"}";
+    }
+
+    /**
+     * @brief Five representative rejection categories - empty, negative, zero, trailing garbage,
+     *        non-numeric. Exhaustive parser-level coverage lives in test_parse_frequency.cpp;
+     *        this sweep verifies the wrapper produces the same Error-return + preserved-out
+     *        behaviour across each distinct rejection class.
+     */
+    std::vector<AssignFrequencyHzRejectionTestCase> makeAssignFrequencyHzRejectionTestCases() {
+        return {
+            AssignFrequencyHzRejectionTestCase{"Empty", ""},
+            AssignFrequencyHzRejectionTestCase{"Negative", "-1"},
+            AssignFrequencyHzRejectionTestCase{"Zero", "0"},
+            AssignFrequencyHzRejectionTestCase{"TrailingGarbage", "100Hz"},
+            AssignFrequencyHzRejectionTestCase{"NonNumeric", "abc"},
+        };
+    }
+}  // namespace
+
+class AssignFrequencyHzRejectionTest
+    : public CapturedStreamsMixin<::testing::TestWithParam<AssignFrequencyHzRejectionTestCase>> {};
+
+/**
+ * @brief Across the rejection axis the wrapper returns Error and leaves the out variable untouched.
+ *
+ * parsedHz is preset to a recognizable 0xDEADBEEF sentinel and asserted to round-trip
+ * unchanged, which catches a "zero out on failure" bug that a weaker "out != arbitrary
+ * pre-test value" check would miss. The Error-return assertion is the second half of the
+ * wrapper's failure-path invariant. Stream capture is handled by the fixture and not
+ * asserted here - the diagnostic-format invariant lives in
+ * FailureDiagnosticContainsErrorPrefixAndOriginalInput.
+ */
+TEST_P(AssignFrequencyHzRejectionTest, PreservesOutVariableAndReturnsError) {
+    constexpr std::uint64_t kSentinelOutValue{0xDEADBEEFULL};
+    const auto& testCase{GetParam()};
+    std::uint64_t parsedHz{kSentinelOutValue};
+
+    const ParseResult result{rpitx::cli::assignFrequencyHz(testCase.input, parsedHz)};
+
+    EXPECT_EQ(result, ParseResult::Error);
+    EXPECT_EQ(parsedHz, kSentinelOutValue);
+}
+
+INSTANTIATE_TEST_SUITE_P(MalformedInputMatrix, AssignFrequencyHzRejectionTest,
+                         ::testing::ValuesIn(makeAssignFrequencyHzRejectionTestCases()),
+                         [](const ::testing::TestParamInfo<AssignFrequencyHzRejectionTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/cli/tests/test_parse_frequency.cpp
+++ b/src/utils/cli/tests/test_parse_frequency.cpp
@@ -87,7 +87,7 @@ TEST_P(ParseFrequencyHzTest, ResolvesToExpectedHz) {
     const auto parsed{parseFrequencyHz(testCase.input)};
 
     ASSERT_TRUE(parsed.has_value());
-    EXPECT_EQ(*parsed, testCase.expectedHz);
+    EXPECT_EQ(parsed.value(), testCase.expectedHz);
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidInputMatrix, ParseFrequencyHzTest, ::testing::ValuesIn(makeValidFrequencyTestCases()),

--- a/src/utils/cli/tests/test_parse_frequency.cpp
+++ b/src/utils/cli/tests/test_parse_frequency.cpp
@@ -68,19 +68,14 @@ class ParseFrequencyHzTest : public ::testing::TestWithParam<ValidFrequencyTestC
 /**
  * @brief Valid frequency text resolves to the corresponding integer Hz value.
  *
- * The input matrix sweeps integer notation across several magnitudes plus scientific
- * notation in lower-case `e`, upper-case `E`, and decimal-mantissa forms whose
- * mathematical result is integer-valued in Hz (e.g. 100.5e6 -> 100_500_000). The
- * AtTwoToTheThirtyTwo case probes the 2^32 boundary and guards against silent 32-bit
- * truncation that smaller cases cannot detect; NearTwoToTheSixtyFour probes the upper
- * boundary at 18_446_744_073_709_549_568 - the largest representable double strictly
- * below 2^64, where the 2048-unit gap to 2^64 equals the double ULP at this magnitude
- * - pinning both the high-end static_cast and the strict `< 2^64` admit-side of the
- * range check. The two assertions split the contract: ASSERT_TRUE pins parse-success
- * and prevents UB in the *parsed dereference below; EXPECT_EQ pins exact-Hz
- * correctness - a regression that returned 0 on success, truncated high bits, or
- * mis-handled the mantissa-to-integer conversion would slip past a has_value()-only
- * check.
+ * AtTwoToTheThirtyTwo guards against silent 32-bit truncation that smaller cases cannot
+ * detect. NearTwoToTheSixtyFour pins the strict `< 2^64` admit-side of the range check at
+ * 18_446_744_073_709_549_568 - the largest representable double strictly below 2^64.
+ *
+ * The split assertions: ASSERT_TRUE prevents parsed.value() from throwing
+ * bad_optional_access on a nullopt regression, giving a clean precondition-style failure;
+ * EXPECT_EQ pins exact-Hz correctness against truncation or mantissa-handling regressions
+ * that a has_value()-only check would miss.
  */
 TEST_P(ParseFrequencyHzTest, ResolvesToExpectedHz) {
     const auto& testCase{GetParam()};
@@ -146,20 +141,13 @@ class ParseFrequencyHzRejectionTest : public ::testing::TestWithParam<InvalidFre
 /**
  * @brief Inputs that violate the parser's contract round-trip to std::nullopt.
  *
- * The rejection axis carries one named case per distinct failure class so a regression
- * in any single gate is attributable from the case name alone. Empty falls at the
- * `text.empty()` early-out; Whitespace and NonNumeric fail std::from_chars with
- * errc::invalid_argument (no characters matched the pattern); ExponentOverflowsDouble
- * fails std::from_chars with errc::result_out_of_range (10^999 exceeds double's
- * exponent range); Trailing* cases pass the parse but trip `ptr != last`;
- * InfinityLiteral and NanLiteral fail std::isfinite; Negative* and Zero* magnitudes
- * fail the `value <= 0` gate; AtTwoToTheSixtyFour and AboveTwoToTheSixtyFour fail
- * the `value >= 0x1p64` upper bound (a distinct gate from ExponentOverflowsDouble -
- * that one overflows double's exponent range, these overflow uint64); and
- * FractionalHz* cases fail the std::modf integer-Hz check.
+ * One named case per distinct failure class so a regression in any single gate is
+ * attributable from the case name alone. AtTwoToTheSixtyFour / AboveTwoToTheSixtyFour
+ * are distinct from ExponentOverflowsDouble - the first two overflow uint64, the latter
+ * overflows double's exponent range.
  *
- * Comparing against std::nullopt rather than negating has_value() keeps failure
- * messages readable - gtest's pretty-printer surfaces the wrapped value on mismatch.
+ * Comparing against std::nullopt rather than negating has_value() keeps failure messages
+ * readable - gtest's pretty-printer surfaces the wrapped value on mismatch.
  */
 TEST_P(ParseFrequencyHzRejectionTest, ReturnsNullopt) {
     const auto& testCase{GetParam()};

--- a/src/utils/cli/tests/test_parse_frequency.cpp
+++ b/src/utils/cli/tests/test_parse_frequency.cpp
@@ -1,0 +1,175 @@
+/**
+ * @file test_parse_frequency.cpp
+ * @brief Unit tests for rpitx::cli::parseFrequencyHz.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 11.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cli_common.h"
+
+namespace {
+    using rpitx::cli::parseFrequencyHz;
+}  // namespace
+
+namespace {
+    struct ValidFrequencyTestCase {
+        std::string_view name;
+        std::string_view input;
+        std::uint64_t expectedHz;
+    };
+
+    /**
+     * @brief Render a ValidFrequencyTestCase as its name plus the raw input text and the
+     *        expected Hz result for gtest listings and failure messages.
+     */
+    void PrintTo(const ValidFrequencyTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\", expectedHz=" << testCase.expectedHz << "}";
+    }
+
+    /**
+     * @brief Inputs the parser must accept: integer decimal notation across several magnitudes,
+     *        scientific notation in both lower- and upper-case `e`, decimal-mantissa scientific
+     *        whose mathematical result is integer-valued in Hz, a value at the 2^32 boundary
+     *        to guard against silent 32-bit truncation, and the largest representable double
+     *        strictly below 2^64 to probe the strict-less-than admit-side of the upper bound.
+     */
+    std::vector<ValidFrequencyTestCase> makeValidFrequencyTestCases() {
+        return {
+            ValidFrequencyTestCase{"IntegerOne", "1", 1ULL},
+            ValidFrequencyTestCase{"IntegerKilohertz", "1000", 1'000ULL},
+            ValidFrequencyTestCase{"IntegerHundredMegahertz", "100000000", 100'000'000ULL},
+            ValidFrequencyTestCase{"ScientificLowerCaseE", "100e6", 100'000'000ULL},
+            ValidFrequencyTestCase{"ScientificUpperCaseE", "100E6", 100'000'000ULL},
+            ValidFrequencyTestCase{"DecimalMantissaIntegerHz", "100.0e6", 100'000'000ULL},
+            ValidFrequencyTestCase{"FractionalMantissaResolvesToInteger", "100.5e6", 100'500'000ULL},
+            ValidFrequencyTestCase{"GigahertzScientific", "1.5e9", 1'500'000'000ULL},
+            ValidFrequencyTestCase{"SixDecimalsResolveToInteger", "1.234567e6", 1'234'567ULL},
+            ValidFrequencyTestCase{"AtTwoToTheThirtyTwo", "4294967296", 4'294'967'296ULL},
+            ValidFrequencyTestCase{"NearTwoToTheSixtyFour", "18446744073709549568", 18'446'744'073'709'549'568ULL},
+        };
+    }
+}  // namespace
+
+class ParseFrequencyHzTest : public ::testing::TestWithParam<ValidFrequencyTestCase> {};
+
+/**
+ * @brief Valid frequency text resolves to the corresponding integer Hz value.
+ *
+ * The input matrix sweeps integer notation across several magnitudes plus scientific
+ * notation in lower-case `e`, upper-case `E`, and decimal-mantissa forms whose
+ * mathematical result is integer-valued in Hz (e.g. 100.5e6 -> 100_500_000). The
+ * AtTwoToTheThirtyTwo case probes the 2^32 boundary and guards against silent 32-bit
+ * truncation that smaller cases cannot detect; NearTwoToTheSixtyFour probes the upper
+ * boundary at 18_446_744_073_709_549_568 - the largest representable double strictly
+ * below 2^64, where the 2048-unit gap to 2^64 equals the double ULP at this magnitude
+ * - pinning both the high-end static_cast and the strict `< 2^64` admit-side of the
+ * range check. The two assertions split the contract: ASSERT_TRUE pins parse-success
+ * and prevents UB in the *parsed dereference below; EXPECT_EQ pins exact-Hz
+ * correctness - a regression that returned 0 on success, truncated high bits, or
+ * mis-handled the mantissa-to-integer conversion would slip past a has_value()-only
+ * check.
+ */
+TEST_P(ParseFrequencyHzTest, ResolvesToExpectedHz) {
+    const auto& testCase{GetParam()};
+    const auto parsed{parseFrequencyHz(testCase.input)};
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(*parsed, testCase.expectedHz);
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidInputMatrix, ParseFrequencyHzTest, ::testing::ValuesIn(makeValidFrequencyTestCases()),
+                         [](const ::testing::TestParamInfo<ValidFrequencyTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct InvalidFrequencyTestCase {
+        std::string_view name;
+        std::string_view input;
+    };
+
+    /**
+     * @brief Render an InvalidFrequencyTestCase as its name plus the rejected input
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const InvalidFrequencyTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\"}";
+    }
+
+    /**
+     * @brief Inputs the parser must reject - one named case per distinct failure class,
+     *        ordered by which parser gate they trip: truly-empty text; whitespace-only
+     *        and wholly-non-numeric input; exponents beyond double's representable range;
+     *        trailing non-numeric content (alphabetic, unit suffix, embedded whitespace,
+     *        mixed-unit); IEEE-754 inf/nan; non-positive magnitudes in both notations;
+     *        values at or above the 2^64 uint64 bound; and sub-integer fractional Hz.
+     */
+    std::vector<InvalidFrequencyTestCase> makeInvalidFrequencyTestCases() {
+        return {
+            InvalidFrequencyTestCase{"Empty", ""},
+            InvalidFrequencyTestCase{"Whitespace", " "},
+            InvalidFrequencyTestCase{"NonNumeric", "abc"},
+            InvalidFrequencyTestCase{"ExponentOverflowsDouble", "1e999"},
+            InvalidFrequencyTestCase{"TrailingAlpha", "100abc"},
+            InvalidFrequencyTestCase{"TrailingUnit", "100Hz"},
+            InvalidFrequencyTestCase{"TrailingSpace", "100 "},
+            InvalidFrequencyTestCase{"TrailingScientificUnit", "1e6kHz"},
+            InvalidFrequencyTestCase{"InfinityLiteral", "inf"},
+            InvalidFrequencyTestCase{"NanLiteral", "nan"},
+            InvalidFrequencyTestCase{"NegativeInteger", "-1"},
+            InvalidFrequencyTestCase{"NegativeScientific", "-1e3"},
+            InvalidFrequencyTestCase{"Zero", "0"},
+            InvalidFrequencyTestCase{"ZeroDecimal", "0.0"},
+            InvalidFrequencyTestCase{"AtTwoToTheSixtyFour", "18446744073709551616"},
+            InvalidFrequencyTestCase{"AboveTwoToTheSixtyFour", "1e20"},
+            InvalidFrequencyTestCase{"FractionalHzDecimal", "100.5"},
+            InvalidFrequencyTestCase{"FractionalHzScientific", "1.55e1"},
+        };
+    }
+}  // namespace
+
+class ParseFrequencyHzRejectionTest : public ::testing::TestWithParam<InvalidFrequencyTestCase> {};
+
+/**
+ * @brief Inputs that violate the parser's contract round-trip to std::nullopt.
+ *
+ * The rejection axis carries one named case per distinct failure class so a regression
+ * in any single gate is attributable from the case name alone. Empty falls at the
+ * `text.empty()` early-out; Whitespace and NonNumeric fail std::from_chars with
+ * errc::invalid_argument (no characters matched the pattern); ExponentOverflowsDouble
+ * fails std::from_chars with errc::result_out_of_range (10^999 exceeds double's
+ * exponent range); Trailing* cases pass the parse but trip `ptr != last`;
+ * InfinityLiteral and NanLiteral fail std::isfinite; Negative* and Zero* magnitudes
+ * fail the `value <= 0` gate; AtTwoToTheSixtyFour and AboveTwoToTheSixtyFour fail
+ * the `value >= 0x1p64` upper bound (a distinct gate from ExponentOverflowsDouble -
+ * that one overflows double's exponent range, these overflow uint64); and
+ * FractionalHz* cases fail the std::modf integer-Hz check.
+ *
+ * Comparing against std::nullopt rather than negating has_value() keeps failure
+ * messages readable - gtest's pretty-printer surfaces the wrapped value on mismatch.
+ */
+TEST_P(ParseFrequencyHzRejectionTest, ReturnsNullopt) {
+    const auto& testCase{GetParam()};
+    const auto parsed{parseFrequencyHz(testCase.input)};
+
+    EXPECT_EQ(parsed, std::nullopt);
+}
+
+INSTANTIATE_TEST_SUITE_P(MalformedInputMatrix, ParseFrequencyHzRejectionTest,
+                         ::testing::ValuesIn(makeInvalidFrequencyTestCases()),
+                         [](const ::testing::TestParamInfo<InvalidFrequencyTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/cli/tests/test_validators.cpp
+++ b/src/utils/cli/tests/test_validators.cpp
@@ -73,21 +73,13 @@ class PositiveFiniteFloatTest : public ::testing::TestWithParam<ValidPositiveFin
 /**
  * @brief Valid positive-finite-float text resolves to an empty diagnostic.
  *
- * The input matrix sweeps integer notation ("1", "100"), decimal-fraction notation in
- * both below-one ("0.5") and above-one ("3.14") flavours, and scientific notation in
- * lower-case 'e' ("1e2"), upper-case 'E' ("1E2"), and negative-exponent ("1.5e-3")
- * forms. The negative-exponent case pins sub-1 admit-side coverage that integer-only
- * sweeps cannot reach - a regression that tightened the lower bound (e.g.
- * value >= 1.0F) would slip past "1" and "100" but fail on "0.5" and "1.5e-3"; the
- * upper-case 'E' case mirrors the parser-test guard against a case-sensitivity
- * regression in the float overload of std::from_chars (the double overload is
- * already pinned by test_parse_frequency.cpp's ScientificUpperCaseE case).
+ * The negative-exponent case pins sub-1 admit-side coverage that integer-only sweeps cannot
+ * reach - a regression that tightened the lower bound (e.g. value >= 1.0F) would slip past
+ * "1" and "100" but fail on "0.5" and "1.5e-3". The upper-case 'E' case guards against a
+ * case-sensitivity regression in the float overload of std::from_chars.
  *
- * Comparing against a literal empty string rather than negating !empty() keeps
- * failure messages readable - gtest's pretty-printer surfaces the unexpected
- * diagnostic on mismatch, immediately revealing which of the two failure-class
- * diagnostics ("must be a numeric value" or "must be a positive finite float") was
- * returned in error.
+ * Comparing against a literal empty string rather than negating !empty() keeps failure
+ * messages readable - gtest's pretty-printer surfaces the unexpected diagnostic on mismatch.
  */
 TEST_P(PositiveFiniteFloatTest, ReturnsEmptyDiagnostic) {
     const auto& testCase{GetParam()};
@@ -147,17 +139,9 @@ class PositiveFiniteFloatRejectionTest : public ::testing::TestWithParam<Invalid
 /**
  * @brief Inputs that violate the validator's contract round-trip to a diagnostic.
  *
- * The rejection axis carries one named case per distinct failure class so a regression
- * in any single gate is attributable from the case name alone, and cases are grouped by
- * which of the validator's two diagnostics they trigger. Cases producing the
- * "must be a numeric value" diagnostic come first: Empty, Whitespace and NonNumeric
- * fail std::from_chars with errc::invalid_argument (no characters matched the float
- * pattern); Trailing* and IncompleteScientific cases pass the parse but trip
- * `ptr != last` (the unconsumed-tail check). Cases producing the "must be a positive
- * finite float" diagnostic follow: ExponentOverflowsFloat fails with
- * errc::result_out_of_range (10^40 exceeds float's exponent range); InfinityLiteral
- * and NanLiteral fail std::isfinite; Zero* and Negative* magnitudes fail the
- * `value <= 0.0F` gate.
+ * One named case per distinct failure class so a regression in any single gate is
+ * attributable from the case name alone, with cases grouped by which of the validator's
+ * two diagnostics they trigger.
  */
 TEST_P(PositiveFiniteFloatRejectionTest, ReturnsDiagnostic) {
     const auto& testCase{GetParam()};
@@ -268,19 +252,10 @@ class FrequencyHzValidatorRejectionTest : public ::testing::TestWithParam<Invali
 /**
  * @brief Inputs the parser rejects round-trip through the wrapper to a diagnostic.
  *
- * The FrequencyHz validator collapses every parseFrequencyHz nullopt return into a
- * single "must be a positive integer Hz value..." diagnostic, so the matrix carries
- * one named case per distinct parser rejection class, ordered by gate ascent.
- * Empty falls at the `text.empty()` early-out; Whitespace and NonNumeric fail
- * std::from_chars with errc::invalid_argument (no characters matched the pattern);
- * ExponentOverflowsDouble fails std::from_chars with errc::result_out_of_range
- * (10^999 exceeds double's exponent range); TrailingUnit passes the parse but
- * trips `ptr != last`; InfinityLiteral and NanLiteral fail std::isfinite;
- * NegativeInteger and Zero fail the `value <= 0` gate; AboveTwoToTheSixtyFour
- * fails the `value >= 0x1p64` upper bound; and FractionalHzDecimal fails the
- * std::modf integer-check. Exhaustive coverage with multiple cases per gate lives
- * in test_parse_frequency.cpp; here this fan-out suffices because the wrapper has
- * a single nullopt-branch.
+ * The FrequencyHz wrapper collapses every parseFrequencyHz nullopt return into a single
+ * diagnostic, so the matrix carries one named case per distinct parser rejection class.
+ * Exhaustive coverage with multiple cases per gate lives in test_parse_frequency.cpp;
+ * here this fan-out suffices because the wrapper has a single nullopt-branch.
  */
 TEST_P(FrequencyHzValidatorRejectionTest, ReturnsDiagnostic) {
     const auto& testCase{GetParam()};

--- a/src/utils/cli/tests/test_validators.cpp
+++ b/src/utils/cli/tests/test_validators.cpp
@@ -1,0 +1,294 @@
+/**
+ * @file test_validators.cpp
+ * @brief Unit tests for the reusable CLI11 validators.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 12.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cli_validators.h"
+
+namespace {
+    using rpitx::cli::validators::FrequencyHz;
+    using rpitx::cli::validators::PositiveFiniteFloat;
+
+    /**
+     * @brief Invoke a CLI11 Validator on a candidate string.
+     *
+     * Validators expose their callback through operator(); the returned string is empty
+     * on accept and a diagnostic on reject. This matches the
+     * CLI::App.add_option(...).check(validator) callsite contract.
+     */
+    std::string runValidator(const CLI::Validator& validator, std::string text) {
+        return validator(text);
+    }
+}  // namespace
+
+namespace {
+    struct ValidPositiveFiniteFloatTestCase {
+        std::string_view name;
+        std::string_view input;
+    };
+
+    /**
+     * @brief Render a ValidPositiveFiniteFloatTestCase as its name plus the accepted
+     *        input for gtest listings and failure messages.
+     */
+    void PrintTo(const ValidPositiveFiniteFloatTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\"}";
+    }
+
+    /**
+     * @brief Inputs the validator must accept: integer notation, decimal-fraction
+     *        notation spanning both below-one and above-one magnitudes, and scientific
+     *        notation across lower-case 'e', upper-case 'E', and negative-exponent
+     *        forms - each variety the validator's std::from_chars parse step must
+     *        handle on the admit side.
+     */
+    std::vector<ValidPositiveFiniteFloatTestCase> makeValidPositiveFiniteFloatTestCases() {
+        return {
+            ValidPositiveFiniteFloatTestCase{"IntegerOne", "1"},
+            ValidPositiveFiniteFloatTestCase{"IntegerHundred", "100"},
+            ValidPositiveFiniteFloatTestCase{"DecimalLessThanOne", "0.5"},
+            ValidPositiveFiniteFloatTestCase{"DecimalGreaterThanOne", "3.14"},
+            ValidPositiveFiniteFloatTestCase{"ScientificLowerCaseE", "1e2"},
+            ValidPositiveFiniteFloatTestCase{"ScientificUpperCaseE", "1E2"},
+            ValidPositiveFiniteFloatTestCase{"ScientificNegativeExponent", "1.5e-3"},
+        };
+    }
+}  // namespace
+
+class PositiveFiniteFloatTest : public ::testing::TestWithParam<ValidPositiveFiniteFloatTestCase> {};
+
+/**
+ * @brief Valid positive-finite-float text resolves to an empty diagnostic.
+ *
+ * The input matrix sweeps integer notation ("1", "100"), decimal-fraction notation in
+ * both below-one ("0.5") and above-one ("3.14") flavours, and scientific notation in
+ * lower-case 'e' ("1e2"), upper-case 'E' ("1E2"), and negative-exponent ("1.5e-3")
+ * forms. The negative-exponent case pins sub-1 admit-side coverage that integer-only
+ * sweeps cannot reach - a regression that tightened the lower bound (e.g.
+ * value >= 1.0F) would slip past "1" and "100" but fail on "0.5" and "1.5e-3"; the
+ * upper-case 'E' case mirrors the parser-test guard against a case-sensitivity
+ * regression in the float overload of std::from_chars (the double overload is
+ * already pinned by test_parse_frequency.cpp's ScientificUpperCaseE case).
+ *
+ * Comparing against a literal empty string rather than negating !empty() keeps
+ * failure messages readable - gtest's pretty-printer surfaces the unexpected
+ * diagnostic on mismatch, immediately revealing which of the two failure-class
+ * diagnostics ("must be a numeric value" or "must be a positive finite float") was
+ * returned in error.
+ */
+TEST_P(PositiveFiniteFloatTest, ReturnsEmptyDiagnostic) {
+    const auto& testCase{GetParam()};
+    EXPECT_EQ(runValidator(PositiveFiniteFloat, std::string{testCase.input}), "");
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidInputMatrix, PositiveFiniteFloatTest,
+                         ::testing::ValuesIn(makeValidPositiveFiniteFloatTestCases()),
+                         [](const ::testing::TestParamInfo<ValidPositiveFiniteFloatTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct InvalidPositiveFiniteFloatTestCase {
+        std::string_view name;
+        std::string_view input;
+    };
+
+    /**
+     * @brief Render an InvalidPositiveFiniteFloatTestCase as its name plus the rejected
+     *        input for gtest listings and failure messages.
+     */
+    void PrintTo(const InvalidPositiveFiniteFloatTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\"}";
+    }
+
+    /**
+     * @brief Inputs the validator must reject - one named case per distinct failure
+     *        class, grouped by which of the validator's two diagnostics they trigger:
+     *        cases producing "must be a numeric value" (empty, whitespace, non-numeric,
+     *        trailing garbage, incomplete scientific) come first, followed by cases
+     *        producing "must be a positive finite float" (overflow, IEEE-754 inf/nan,
+     *        and non-positive magnitudes in decimal and scientific notation).
+     */
+    std::vector<InvalidPositiveFiniteFloatTestCase> makeInvalidPositiveFiniteFloatTestCases() {
+        return {
+            InvalidPositiveFiniteFloatTestCase{"Empty", ""},
+            InvalidPositiveFiniteFloatTestCase{"Whitespace", " "},
+            InvalidPositiveFiniteFloatTestCase{"NonNumeric", "abc"},
+            InvalidPositiveFiniteFloatTestCase{"TrailingAlpha", "1.0xyz"},
+            InvalidPositiveFiniteFloatTestCase{"TrailingSpace", "1.0 "},
+            InvalidPositiveFiniteFloatTestCase{"IncompleteScientific", "1.0e"},
+            InvalidPositiveFiniteFloatTestCase{"ExponentOverflowsFloat", "1e40"},
+            InvalidPositiveFiniteFloatTestCase{"InfinityLiteral", "inf"},
+            InvalidPositiveFiniteFloatTestCase{"NanLiteral", "nan"},
+            InvalidPositiveFiniteFloatTestCase{"Zero", "0"},
+            InvalidPositiveFiniteFloatTestCase{"ZeroDecimal", "0.0"},
+            InvalidPositiveFiniteFloatTestCase{"NegativeInteger", "-1"},
+            InvalidPositiveFiniteFloatTestCase{"NegativeDecimal", "-1.0"},
+            InvalidPositiveFiniteFloatTestCase{"NegativeScientific", "-1e3"},
+        };
+    }
+}  // namespace
+
+class PositiveFiniteFloatRejectionTest : public ::testing::TestWithParam<InvalidPositiveFiniteFloatTestCase> {};
+
+/**
+ * @brief Inputs that violate the validator's contract round-trip to a diagnostic.
+ *
+ * The rejection axis carries one named case per distinct failure class so a regression
+ * in any single gate is attributable from the case name alone, and cases are grouped by
+ * which of the validator's two diagnostics they trigger. Cases producing the
+ * "must be a numeric value" diagnostic come first: Empty, Whitespace and NonNumeric
+ * fail std::from_chars with errc::invalid_argument (no characters matched the float
+ * pattern); Trailing* and IncompleteScientific cases pass the parse but trip
+ * `ptr != last` (the unconsumed-tail check). Cases producing the "must be a positive
+ * finite float" diagnostic follow: ExponentOverflowsFloat fails with
+ * errc::result_out_of_range (10^40 exceeds float's exponent range); InfinityLiteral
+ * and NanLiteral fail std::isfinite; Zero* and Negative* magnitudes fail the
+ * `value <= 0.0F` gate.
+ */
+TEST_P(PositiveFiniteFloatRejectionTest, ReturnsDiagnostic) {
+    const auto& testCase{GetParam()};
+    EXPECT_NE(runValidator(PositiveFiniteFloat, std::string{testCase.input}), "");
+}
+
+INSTANTIATE_TEST_SUITE_P(MalformedInputMatrix, PositiveFiniteFloatRejectionTest,
+                         ::testing::ValuesIn(makeInvalidPositiveFiniteFloatTestCases()),
+                         [](const ::testing::TestParamInfo<InvalidPositiveFiniteFloatTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct ValidFrequencyHzValidatorTestCase {
+        std::string_view name;
+        std::string_view input;
+    };
+
+    /**
+     * @brief Render a ValidFrequencyHzValidatorTestCase as its name plus the accepted
+     *        input for gtest listings and failure messages.
+     */
+    void PrintTo(const ValidFrequencyHzValidatorTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\"}";
+    }
+
+    /**
+     * @brief A representative subset of parseFrequencyHz's accept axis - one named
+     *        case per distinct parser admit class: integer Hz, scientific Hz, decimal-
+     *        mantissa scientific resolving to integer Hz, and magnitudes across the
+     *        megahertz / gigahertz range.
+     */
+    std::vector<ValidFrequencyHzValidatorTestCase> makeValidFrequencyHzValidatorTestCases() {
+        return {
+            ValidFrequencyHzValidatorTestCase{"IntegerHertz", "1"},
+            ValidFrequencyHzValidatorTestCase{"IntegerHundredMegahertz", "100000000"},
+            ValidFrequencyHzValidatorTestCase{"ScientificMegahertz", "100e6"},
+            ValidFrequencyHzValidatorTestCase{"DecimalMantissaIntegerHz", "100.5e6"},
+            ValidFrequencyHzValidatorTestCase{"GigahertzScientific", "1.5e9"},
+        };
+    }
+}  // namespace
+
+class FrequencyHzValidatorTest : public ::testing::TestWithParam<ValidFrequencyHzValidatorTestCase> {};
+
+/**
+ * @brief Valid frequency text resolves to an empty diagnostic.
+ *
+ * The FrequencyHz validator delegates to parseFrequencyHz, so the input matrix here is
+ * a representative subset of the parser's accept axis - exhaustive parser-level
+ * coverage lives in test_parse_frequency.cpp. The cases span integer notation,
+ * scientific notation, and decimal-mantissa scientific resolving to integer Hz,
+ * across magnitudes from 1 Hz to 1.5 GHz, verifying that each parser-level admit
+ * class survives the wrapper's std::nullopt-to-empty-string translation.
+ */
+TEST_P(FrequencyHzValidatorTest, ReturnsEmptyDiagnostic) {
+    const auto& testCase{GetParam()};
+    EXPECT_EQ(runValidator(FrequencyHz, std::string{testCase.input}), "");
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidInputMatrix, FrequencyHzValidatorTest,
+                         ::testing::ValuesIn(makeValidFrequencyHzValidatorTestCases()),
+                         [](const ::testing::TestParamInfo<ValidFrequencyHzValidatorTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct InvalidFrequencyHzValidatorTestCase {
+        std::string_view name;
+        std::string_view input;
+    };
+
+    /**
+     * @brief Render an InvalidFrequencyHzValidatorTestCase as its name plus the rejected
+     *        input for gtest listings and failure messages.
+     */
+    void PrintTo(const InvalidFrequencyHzValidatorTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {input=\"" << testCase.input << "\"}";
+    }
+
+    /**
+     * @brief One named case per distinct parser rejection class the wrapper must
+     *        surface as a diagnostic, ordered by which parser gate they trip:
+     *        truly-empty text; whitespace-only and wholly non-numeric input;
+     *        exponents beyond double's representable range; trailing unit suffix;
+     *        IEEE-754 inf/nan; non-positive magnitudes; 2^64 overflow; and
+     *        fractional Hz.
+     */
+    std::vector<InvalidFrequencyHzValidatorTestCase> makeInvalidFrequencyHzValidatorTestCases() {
+        return {
+            InvalidFrequencyHzValidatorTestCase{"Empty", ""},
+            InvalidFrequencyHzValidatorTestCase{"Whitespace", " "},
+            InvalidFrequencyHzValidatorTestCase{"NonNumeric", "abc"},
+            InvalidFrequencyHzValidatorTestCase{"ExponentOverflowsDouble", "1e999"},
+            InvalidFrequencyHzValidatorTestCase{"TrailingUnit", "100Hz"},
+            InvalidFrequencyHzValidatorTestCase{"InfinityLiteral", "inf"},
+            InvalidFrequencyHzValidatorTestCase{"NanLiteral", "nan"},
+            InvalidFrequencyHzValidatorTestCase{"NegativeInteger", "-1"},
+            InvalidFrequencyHzValidatorTestCase{"Zero", "0"},
+            InvalidFrequencyHzValidatorTestCase{"AboveTwoToTheSixtyFour", "1e20"},
+            InvalidFrequencyHzValidatorTestCase{"FractionalHzDecimal", "100.5"},
+        };
+    }
+}  // namespace
+
+class FrequencyHzValidatorRejectionTest : public ::testing::TestWithParam<InvalidFrequencyHzValidatorTestCase> {};
+
+/**
+ * @brief Inputs the parser rejects round-trip through the wrapper to a diagnostic.
+ *
+ * The FrequencyHz validator collapses every parseFrequencyHz nullopt return into a
+ * single "must be a positive integer Hz value..." diagnostic, so the matrix carries
+ * one named case per distinct parser rejection class, ordered by gate ascent.
+ * Empty falls at the `text.empty()` early-out; Whitespace and NonNumeric fail
+ * std::from_chars with errc::invalid_argument (no characters matched the pattern);
+ * ExponentOverflowsDouble fails std::from_chars with errc::result_out_of_range
+ * (10^999 exceeds double's exponent range); TrailingUnit passes the parse but
+ * trips `ptr != last`; InfinityLiteral and NanLiteral fail std::isfinite;
+ * NegativeInteger and Zero fail the `value <= 0` gate; AboveTwoToTheSixtyFour
+ * fails the `value >= 0x1p64` upper bound; and FractionalHzDecimal fails the
+ * std::modf integer-check. Exhaustive coverage with multiple cases per gate lives
+ * in test_parse_frequency.cpp; here this fan-out suffices because the wrapper has
+ * a single nullopt-branch.
+ */
+TEST_P(FrequencyHzValidatorRejectionTest, ReturnsDiagnostic) {
+    const auto& testCase{GetParam()};
+    EXPECT_NE(runValidator(FrequencyHz, std::string{testCase.input}), "");
+}
+
+INSTANTIATE_TEST_SUITE_P(MalformedInputMatrix, FrequencyHzValidatorRejectionTest,
+                         ::testing::ValuesIn(makeInvalidFrequencyHzValidatorTestCases()),
+                         [](const ::testing::TestParamInfo<InvalidFrequencyHzValidatorTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/dsp/CMakeLists.txt
+++ b/src/utils/dsp/CMakeLists.txt
@@ -22,3 +22,7 @@ add_library(rpitx_dsp_utils STATIC
 )
 target_include_directories(rpitx_dsp_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpitx_dsp_utils PRIVATE m)
+
+if(ENABLE_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/src/utils/dsp/CMakeLists.txt
+++ b/src/utils/dsp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
-# Date: 02.05.2026
+# Date: 15.05.2026
 # License: GPL-3.0
 # Fork: https://github.com/IgrikXD/rpitx-ui
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.

--- a/src/utils/dsp/agc.h
+++ b/src/utils/dsp/agc.h
@@ -47,6 +47,12 @@ struct AgcConfig {
 class Agc {
 public:
     /**
+     * @brief Envelope magnitude below which updateGain() clamps to unity instead of dividing
+     *        by the near-zero envelope, keeping the gain finite when no signal is present.
+     */
+    static constexpr float ENVELOPE_FLOOR{1e-6F};
+
+    /**
      * @brief Construct an AGC with the given configuration.
      * @param config AGC parameters.
      */
@@ -99,7 +105,7 @@ public:
             env_ += decay_ * (mag - env_);
         }
 
-        if (env_ > 1e-6f) {
+        if (env_ > ENVELOPE_FLOOR) {
             return target_ / env_;
         }
         return 1.0f;

--- a/src/utils/dsp/tests/CMakeLists.txt
+++ b/src/utils/dsp/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 05.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Unit tests for the shared DSP utility library
+# ----------------------------------------------------------
+add_executable(rpitx_dsp_utils_tests
+    test_agc.cpp
+    test_biquad.cpp
+    test_hilbert.cpp
+    test_iq_sample.cpp
+)
+
+target_link_libraries(rpitx_dsp_utils_tests
+    PRIVATE
+        rpitx_dsp_utils
+        GTest::gtest
+        GTest::gtest_main
+)
+
+# CTest integration: discover each TEST/TEST_P/TEST_F as an individual ctest
+# entry so a failing case is reported by name instead of being lumped under
+# the whole binary.
+gtest_discover_tests(rpitx_dsp_utils_tests
+    PROPERTIES LABELS "unit;dsp"
+)

--- a/src/utils/dsp/tests/test_agc.cpp
+++ b/src/utils/dsp/tests/test_agc.cpp
@@ -1,0 +1,234 @@
+/**
+ * @file test_agc.cpp
+ * @brief Unit tests for the envelope-tracking AGC.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 05.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "agc.h"
+
+namespace {
+    /**
+     * @brief Snaps the envelope to |input| in one step (attack=decay=1) - simplifies analytical
+     *        expectations across most basic tests by removing transient settling behavior.
+     */
+    constexpr AgcConfig kFastConfig{
+        .target          = 1.0F,
+        .attack          = 1.0F,
+        .decay           = 1.0F,
+        .initialEnvelope = 1e-4F,
+    };
+
+    /**
+     * @brief Peak-hold tracker (attack >> decay): envelope rises quickly under saturation but
+     *        relaxes slowly when the magnitude collapses.
+     */
+    constexpr AgcConfig kAsymmetricConfig{
+        .target          = 0.8F,
+        .attack          = 0.5F,
+        .decay           = 0.01F,
+        .initialEnvelope = 1e-4F,
+    };
+
+    /**
+     * @brief Initial envelope below the 1e-6 floor - exercises the construct-time path where the
+     *        AGC clamps gain to unity before any signal is observed.
+     */
+    constexpr AgcConfig kZeroEnvelopeConfig{
+        .target          = 1.0F,
+        .attack          = 1.0F,
+        .decay           = 1.0F,
+        .initialEnvelope = 0.0F,
+    };
+
+    /**
+     * @brief Non-unity target verifies that process() reads the configured target instead of a
+     *        hardcoded 1.0.
+     */
+    constexpr AgcConfig kHalfTargetConfig{
+        .target          = 0.5F,
+        .attack          = 1.0F,
+        .decay           = 1.0F,
+        .initialEnvelope = 1e-4F,
+    };
+}  // namespace
+
+/**
+ * @brief Floor branch returns unity gain when envelope and magnitude are both zero.
+ *
+ * Constructed with a zero initial envelope and fed a zero magnitude, the AGC must return
+ * unity rather than diverge - the 1e-6 envelope floor keeps the gain finite when no signal
+ * is present.
+ */
+TEST(AgcTest, FloorYieldsUnityGainWhenEnvelopeNearZero) {
+    Agc agc{kZeroEnvelopeConfig};
+    const float gain{agc.updateGain(0.0F)};
+
+    EXPECT_FLOAT_EQ(gain, 1.0F);
+}
+
+/**
+ * @brief IQ process() scales each component by gain = target / |input|.
+ *
+ * With kFastConfig (attack=1) the envelope snaps to |input| immediately. For input magnitude
+ * 0.5 against target=1 the gain resolves to 2.0 and both components are doubled - using a
+ * non-unity gain distinguishes a correct scale-by-gain implementation from one that returns
+ * the input unchanged.
+ */
+TEST(AgcTest, IqProcessAppliesGainOfTargetOverEnvelope) {
+    Agc agc{kFastConfig};
+    const IqSample input{.i = 0.3F, .q = 0.4F};  // |input| = 0.5
+    const IqSample out{agc.process(input)};
+
+    EXPECT_NEAR(out.i, 0.6F, 1e-5F);
+    EXPECT_NEAR(out.q, 0.8F, 1e-5F);
+}
+
+/**
+ * @brief Scalar process() normalizes its output to the configured target amplitude.
+ *
+ * With kHalfTargetConfig (target=0.5, attack=1) the envelope snaps to |input|=0.25, the gain
+ * resolves to 2.0, and the scaled output equals target=0.5.
+ */
+TEST(AgcTest, ScalarProcessNormalizesToTargetAmplitude) {
+    Agc agc{kHalfTargetConfig};
+    const float out{agc.process(0.25F)};
+
+    EXPECT_NEAR(out, 0.5F, 1e-5F);
+}
+
+/**
+ * @brief A zero IqSample must produce a finite output, never NaN.
+ *
+ * When the envelope collapses to the floor as |input| goes to zero, the SUT clamps gain
+ * instead of dividing by the near-zero envelope, so the output stays finite for both
+ * components.
+ */
+TEST(AgcTest, ZeroInputDoesNotProduceNaN) {
+    Agc agc{kFastConfig};
+    const IqSample zeroInput{.i = 0.0F, .q = 0.0F};
+    const IqSample out{agc.process(zeroInput)};
+
+    EXPECT_TRUE(std::isfinite(out.i));
+    EXPECT_TRUE(std::isfinite(out.q));
+}
+
+/**
+ * @brief Asymmetric attack/decay produces fast rise, slow fall in the gain response.
+ *
+ * With attack=0.5 the envelope rises quickly under saturation, but decay=0.01 leaves it nearly
+ * held when the magnitude collapses. The warm-up loop saturates with unity samples so the
+ * envelope converges geometrically (env_N = 1 - 0.5^N * (1 - env_0)) to within float precision
+ * of 1.0 before the measurement.
+ *
+ * After settling, dropping the magnitude to 0.1 advances the envelope by only one decay step:
+ * env_new = 1 + decay*(0.1 - 1) = 0.991, so the gain shifts by ~0.007 - far less than a
+ * symmetric tracker that would jump toward target/0.1. The 0.02 tolerance leaves ~3x slack
+ * against the analytical estimate while still catching large regressions.
+ */
+TEST(AgcTest, AsymmetricAttackDecayCausesFastRiseSlowFall) {
+    Agc agc{kAsymmetricConfig};
+
+    constexpr int kEnvelopeSettleSamples{50};
+    for (int i{0}; i < kEnvelopeSettleSamples; ++i) {
+        [[maybe_unused]] const float warmupGain{agc.updateGain(1.0F)};
+    }
+    const float gainAtFullScale{agc.updateGain(1.0F)};
+    const float gainAfterDrop{agc.updateGain(0.1F)};
+
+    EXPECT_NEAR(gainAfterDrop, gainAtFullScale, 0.02F);
+}
+
+namespace {
+    struct AgcUpdateGainTestCase {
+        std::string_view name;
+        float magnitude;
+        float expectedGain;
+    };
+
+    /**
+     * @brief Render an AgcUpdateGainTestCase as its name plus magnitude/expected gain
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const AgcUpdateGainTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {magnitude=" << testCase.magnitude << ", expectedGain=" << testCase.expectedGain
+            << "}";
+    }
+
+    /**
+     * @brief Magnitudes above the 1e-6 envelope floor where gain = target / |magnitude| (target=1).
+     */
+    std::vector<AgcUpdateGainTestCase> makeAboveFloorTestCases() {
+        return {
+            AgcUpdateGainTestCase{"Micro", 1e-5F, 1.0e5F},
+            AgcUpdateGainTestCase{"Milli", 1e-3F, 1.0e3F},
+            AgcUpdateGainTestCase{"Tenth", 0.1F, 10.0F},
+            AgcUpdateGainTestCase{"Unity", 1.0F, 1.0F},
+            AgcUpdateGainTestCase{"FiveTimes", 5.0F, 0.2F},
+            AgcUpdateGainTestCase{"Hundred", 100.0F, 0.01F},
+        };
+    }
+
+    /**
+     * @brief Magnitudes at or below the 1e-6 envelope floor where the AGC clamps gain to unity.
+     */
+    std::vector<AgcUpdateGainTestCase> makeBelowFloorTestCases() {
+        return {
+            AgcUpdateGainTestCase{"ExactlyZero", 0.0F, 1.0F},
+            AgcUpdateGainTestCase{"NearZero", 1e-7F, 1.0F},
+        };
+    }
+}  // namespace
+
+class AgcUpdateGainAboveFloorTest : public ::testing::TestWithParam<AgcUpdateGainTestCase> {};
+
+/**
+ * @brief Above the envelope floor the gain matches target / |magnitude| within float precision.
+ *
+ * Uses a relative tolerance scaled by the expected value: at magnitude=1e-5 the expected gain
+ * is 1e5, so a single-precision relative error of ~1e-7 already exceeds any sane absolute
+ * tolerance. Scaling the bound to the expected value keeps the check meaningful across the
+ * magnitude sweep.
+ */
+TEST_P(AgcUpdateGainAboveFloorTest, MatchesTargetOverEnvelope) {
+    const auto& testCase{GetParam()};
+    Agc agc{kFastConfig};
+    const float gain{agc.updateGain(testCase.magnitude)};
+
+    EXPECT_NEAR(gain, testCase.expectedGain, std::abs(testCase.expectedGain) * 1e-4F);
+}
+
+INSTANTIATE_TEST_SUITE_P(MagnitudeSweep, AgcUpdateGainAboveFloorTest, ::testing::ValuesIn(makeAboveFloorTestCases()),
+                         [](const ::testing::TestParamInfo<AgcUpdateGainTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+class AgcUpdateGainBelowFloorTest : public ::testing::TestWithParam<AgcUpdateGainTestCase> {};
+
+/**
+ * @brief At or below the envelope floor the SUT clamps gain to unity to avoid divide-by-zero blow-up.
+ */
+TEST_P(AgcUpdateGainBelowFloorTest, ClampsToUnity) {
+    const auto& testCase{GetParam()};
+    Agc agc{kFastConfig};
+    const float gain{agc.updateGain(testCase.magnitude)};
+
+    EXPECT_FLOAT_EQ(gain, testCase.expectedGain);
+}
+
+INSTANTIATE_TEST_SUITE_P(MagnitudeSweep, AgcUpdateGainBelowFloorTest, ::testing::ValuesIn(makeBelowFloorTestCases()),
+                         [](const ::testing::TestParamInfo<AgcUpdateGainTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/dsp/tests/test_agc.cpp
+++ b/src/utils/dsp/tests/test_agc.cpp
@@ -43,8 +43,8 @@ namespace {
     };
 
     /**
-     * @brief Initial envelope below the 1e-6 floor - exercises the construct-time path where the
-     *        AGC clamps gain to unity before any signal is observed.
+     * @brief Initial envelope below Agc::ENVELOPE_FLOOR - exercises the construct-time path where
+     *        the AGC clamps gain to unity before any signal is observed.
      */
     constexpr AgcConfig kZeroEnvelopeConfig{
         .target          = 1.0F,
@@ -69,8 +69,8 @@ namespace {
  * @brief Floor branch returns unity gain when envelope and magnitude are both zero.
  *
  * Constructed with a zero initial envelope and fed a zero magnitude, the AGC must return
- * unity rather than diverge - the 1e-6 envelope floor keeps the gain finite when no signal
- * is present.
+ * unity rather than diverge - the Agc::ENVELOPE_FLOOR clamp keeps the gain finite when no
+ * signal is present.
  */
 TEST(AgcTest, FloorYieldsUnityGainWhenEnvelopeNearZero) {
     Agc agc{kZeroEnvelopeConfig};
@@ -168,7 +168,7 @@ namespace {
     }
 
     /**
-     * @brief Magnitudes above the 1e-6 envelope floor where gain = target / |magnitude| (target=1).
+     * @brief Magnitudes above Agc::ENVELOPE_FLOOR where gain = target / |magnitude| (target=1).
      */
     std::vector<AgcUpdateGainTestCase> makeAboveFloorTestCases() {
         return {
@@ -182,12 +182,14 @@ namespace {
     }
 
     /**
-     * @brief Magnitudes at or below the 1e-6 envelope floor where the AGC clamps gain to unity.
+     * @brief Magnitudes at or below Agc::ENVELOPE_FLOOR where the AGC clamps gain to unity.
+     *        NearZero is expressed as ENVELOPE_FLOOR / 10 so the "one order of magnitude below
+     *        floor" relationship survives a floor retune without manual edits to the literal.
      */
     std::vector<AgcUpdateGainTestCase> makeBelowFloorTestCases() {
         return {
             AgcUpdateGainTestCase{"ExactlyZero", 0.0F, 1.0F},
-            AgcUpdateGainTestCase{"NearZero", 1e-7F, 1.0F},
+            AgcUpdateGainTestCase{"NearZero", Agc::ENVELOPE_FLOOR / 10.0F, 1.0F},
         };
     }
 }  // namespace

--- a/src/utils/dsp/tests/test_biquad.cpp
+++ b/src/utils/dsp/tests/test_biquad.cpp
@@ -1,0 +1,503 @@
+/**
+ * @file test_biquad.cpp
+ * @brief Unit tests for the Biquad IIR filter and its design factories.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 05.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <numbers>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "biquad.h"
+
+namespace {
+
+    /**
+     * @brief Drive the biquad with a unit-amplitude sinusoid at the requested frequency
+     *        and return the steady-state output peak amplitude.
+     *
+     * After kSettleSamples warmup samples the IIR transient has decayed below the noise
+     * floor of the assertions below for any cutoff/rate combination exercised here; the
+     * peak of the next kMeasureSamples then reads |H(omega)| of the filter. Used by every
+     * frequency-response test in this TU.
+     */
+    float steadyStatePeak(Biquad& biquad, float freqHz, float sampleRate) {
+        constexpr int kSettleSamples{4000};
+        constexpr int kMeasureSamples{2000};
+        const float omega{2.0F * std::numbers::pi_v<float> * freqHz / sampleRate};
+
+        for (int n{0}; n < kSettleSamples; ++n) {
+            [[maybe_unused]] const float warmupOutput{biquad.process(std::sin(omega * static_cast<float>(n)))};
+        }
+
+        float peak{0.0F};
+        for (int n{0}; n < kMeasureSamples; ++n) {
+            const float sampleIndex{static_cast<float>(kSettleSamples + n)};
+            const float output{biquad.process(std::sin(omega * sampleIndex))};
+            peak = std::max(peak, std::abs(output));
+        }
+        return peak;
+    }
+
+}  // namespace
+
+/**
+ * @brief BUTTERWORTH_Q exposes 1/sqrt(2) - the canonical 2nd-order Butterworth pole-pair Q.
+ *
+ * Pinning the public constant against the formula prevents drift between the documented
+ * value (used at call sites for custom-Q cascade design) and the in-class initializer.
+ * Both sides resolve to the same `1.0F / std::numbers::sqrt2_v<float>` expression so
+ * equality is bit-exact.
+ */
+TEST(BiquadTest, ButterworthQConstantMatchesOneOverSqrtTwo) {
+    EXPECT_FLOAT_EQ(Biquad::BUTTERWORTH_Q, 1.0F / std::numbers::sqrt2_v<float>);
+}
+
+/**
+ * @brief Sustained zero input produces zero output across a multi-sample run.
+ *
+ * Verifies that delay lines initialize to zero (no construction-time noise) and that the
+ * Direct-Form-I difference equation preserves the all-zero state across iterations. The
+ * highPass factory choice is incidental - the property holds for any biquad coefficients
+ * given zero state and input. Running 100 samples (>> 2-sample delay line) ensures any
+ * drift would surface as a non-zero output.
+ */
+TEST(BiquadTest, ZeroInputProducesZeroOutput) {
+    constexpr float kCutoffHz{1'000.0F};
+    constexpr float kSampleRate{48'000.0F};
+    constexpr int kZeroInputSamples{100};
+
+    Biquad biquad{Biquad::highPass(kCutoffHz, kSampleRate)};
+
+    for (int n{0}; n < kZeroInputSamples; ++n) {
+        const float output{biquad.process(0.0F)};
+        EXPECT_FLOAT_EQ(output, 0.0F);
+    }
+}
+
+/**
+ * @brief Process loop output matches the convolution of input with the captured impulse response.
+ *
+ * For any LTI filter y[n] = sum_k h[k] * x[n-k]. We capture h[0..5] from one fresh biquad
+ * fed an impulse, then drive a second fresh biquad with a known mixed-sign input pattern
+ * and verify each output equals the truncated convolution sum. Bugs that break LTI -
+ * swapped y1/y2, flipped a1 sign, reversed delay-line update order - would surface here.
+ * Filter type/cutoff is incidental; the test validates process(), not the coefficients.
+ * For 6 multiplies of values bounded by ~1, expected absolute roundoff is on the order
+ * of 1e-7 (float relative epsilon ~6e-8 per op), so the 1e-5 tolerance leaves ~100x
+ * margin against the divergence between the recursive Direct-Form-I path (SUT) and the
+ * open-loop convolution path (reference).
+ */
+TEST(BiquadTest, ProcessLoopMatchesConvolutionAgainstImpulseResponse) {
+    constexpr float kCutoffHz{2'000.0F};
+    constexpr float kSampleRate{48'000.0F};
+    constexpr std::array<float, 6> kInputPattern{0.5F, 0.3F, -0.2F, 0.7F, -0.4F, 0.1F};
+    constexpr float kConvolutionTolerance{1e-5F};
+
+    Biquad biquadImpulse{Biquad::lowPass(kCutoffHz, kSampleRate)};
+    std::array<float, kInputPattern.size()> impulseResponse{};
+    impulseResponse[0] = biquadImpulse.process(1.0F);
+    for (std::size_t n{1}; n < impulseResponse.size(); ++n) {
+        impulseResponse[n] = biquadImpulse.process(0.0F);
+    }
+
+    Biquad biquadInput{Biquad::lowPass(kCutoffHz, kSampleRate)};
+    std::array<float, kInputPattern.size()> output{};
+    for (std::size_t n{0}; n < kInputPattern.size(); ++n) {
+        output[n] = biquadInput.process(kInputPattern[n]);
+    }
+
+    for (std::size_t n{0}; n < kInputPattern.size(); ++n) {
+        float reference{0.0F};
+        for (std::size_t k{0}; k <= n; ++k) {
+            reference += impulseResponse[n - k] * kInputPattern[k];
+        }
+        EXPECT_NEAR(output[n], reference, kConvolutionTolerance) << "Mismatch at sample " << n;
+    }
+}
+
+/**
+ * @brief A high-pass biquad fed sustained DC settles to zero output.
+ *
+ * The high-pass transfer has a zero at z=1 (DC), so |H(0)| = 0. After kSettleSamples the
+ * IIR transient has decayed into the float noise floor; the 1e-3 tolerance leaves slack
+ * against residual transient and Direct-Form-I roundoff at this cutoff/fs.
+ */
+TEST(BiquadTest, HighPassAttenuatesDc) {
+    constexpr float kCutoffHz{300.0F};
+    constexpr float kSampleRate{48'000.0F};
+    constexpr int kSettleSamples{5000};
+    constexpr float kDcResidualTolerance{1e-3F};
+
+    Biquad biquad{Biquad::highPass(kCutoffHz, kSampleRate)};
+
+    float lastOutput{0.0F};
+    for (int i{0}; i < kSettleSamples; ++i) {
+        lastOutput = biquad.process(1.0F);
+    }
+
+    EXPECT_NEAR(lastOutput, 0.0F, kDcResidualTolerance);
+}
+
+/**
+ * @brief A high-pass biquad reaches near-unity peak amplitude well above its cutoff.
+ *
+ * At a tone frequency more than a decade above the 300 Hz Butterworth cutoff (4 kHz here)
+ * the magnitude response is well into the passband, so |H(jw)| -> 1. The 0.05 tolerance
+ * accommodates discrete-time prewarp drift.
+ */
+TEST(BiquadTest, HighPassPassesFrequencyWellAboveCutoff) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kCutoffHz{300.0F};
+    constexpr float kPassbandToneHz{4'000.0F};
+    constexpr float kPassbandTolerance{0.05F};
+
+    Biquad biquad{Biquad::highPass(kCutoffHz, kSampleRate)};
+    const float peak{steadyStatePeak(biquad, kPassbandToneHz, kSampleRate)};
+
+    EXPECT_NEAR(peak, 1.0F, kPassbandTolerance);
+}
+
+/**
+ * @brief A Butterworth-Q high-pass biquad reaches -3 dB amplitude at its cutoff frequency.
+ *
+ * Special case of the universal RBJ property |H(jw_c)| = Q with q = BUTTERWORTH_Q: the
+ * magnitude at the corner equals 1/sqrt(2) ~= 0.7071, the defining -3 dB point of the
+ * Butterworth response. The 0.05 tolerance accommodates bilinear prewarp shift of the
+ * corner relative to the analog prototype.
+ */
+TEST(BiquadTest, HighPassMinusThreeDbAtCutoffWithButterworthQ) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kCutoffHz{1'000.0F};
+    constexpr float kCutoffMagnitudeTolerance{0.05F};
+
+    Biquad biquad{Biquad::highPass(kCutoffHz, kSampleRate)};
+    const float peak{steadyStatePeak(biquad, kCutoffHz, kSampleRate)};
+
+    EXPECT_NEAR(peak, Biquad::BUTTERWORTH_Q, kCutoffMagnitudeTolerance);
+}
+
+/**
+ * @brief A non-default Q on the high-pass biquad sets the cutoff magnitude to Q.
+ *
+ * Mirror of the LPF Q-sweep at a single Q=2 case, validating that the q parameter is
+ * wired through highPass() as well. For a 2nd-order RBJ section, |H(jw_c)| = Q
+ * analytically, so Q=2 pins the magnitude at 2.0; if q were ignored and treated as the
+ * Butterworth default (~0.707), the measured peak would land near 0.707 - far outside
+ * the 5% relative tolerance around the expected 2.0.
+ */
+TEST(BiquadTest, HighPassCutoffMagnitudeMatchesCustomQ) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kCutoffHz{1'000.0F};
+    constexpr float kCustomQ{2.0F};
+    constexpr float kRelativeTolerance{0.05F};
+
+    Biquad biquad{Biquad::highPass(kCutoffHz, kSampleRate, kCustomQ)};
+    const float peak{steadyStatePeak(biquad, kCutoffHz, kSampleRate)};
+
+    EXPECT_NEAR(peak, kCustomQ, kCustomQ * kRelativeTolerance);
+}
+
+/**
+ * @brief A low-pass biquad fed sustained DC tracks the input unattenuated.
+ *
+ * The low-pass transfer has unity DC gain (|H(0)| = 1). After kSettleSamples the transient
+ * has died out so the output equals the DC input within float roundoff. The 1e-3 tolerance
+ * mirrors HighPassAttenuatesDc's "transient-floor" margin.
+ */
+TEST(BiquadTest, LowPassPassesDcCleanly) {
+    constexpr float kCutoffHz{3'000.0F};
+    constexpr float kSampleRate{48'000.0F};
+    constexpr int kSettleSamples{5000};
+    constexpr float kDcResidualTolerance{1e-3F};
+
+    Biquad biquad{Biquad::lowPass(kCutoffHz, kSampleRate)};
+
+    float lastOutput{0.0F};
+    for (int i{0}; i < kSettleSamples; ++i) {
+        lastOutput = biquad.process(1.0F);
+    }
+
+    EXPECT_NEAR(lastOutput, 1.0F, kDcResidualTolerance);
+}
+
+/**
+ * @brief A low-pass biquad attenuates a tone well above cutoff to a small fraction of unity.
+ *
+ * The 2nd-order Butterworth analog prototype gives |H(jw)| = 1 / sqrt(1 + (w/w_c)^4) ~=
+ * 0.007 at w/w_c=12 (1 kHz cutoff vs 12 kHz tone); the digital RBJ implementation rolls
+ * off slightly steeper due to its zero at z=-1 (Nyquist) and measures around 0.004. The
+ * 0.05 upper bound leaves wide slack against either while still flagging a regression to
+ * first-order rolloff (-6 dB/oct gives |H| ~= 0.083, above the bound).
+ */
+TEST(BiquadTest, LowPassAttenuatesFrequencyWellAboveCutoff) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kCutoffHz{1'000.0F};
+    constexpr float kStopbandToneHz{12'000.0F};
+    constexpr float kStopbandUpperBound{0.05F};
+
+    Biquad biquad{Biquad::lowPass(kCutoffHz, kSampleRate)};
+    const float peak{steadyStatePeak(biquad, kStopbandToneHz, kSampleRate)};
+
+    EXPECT_LT(peak, kStopbandUpperBound);
+}
+
+/**
+ * @brief A Butterworth-Q low-pass biquad reaches -3 dB amplitude at its cutoff frequency.
+ *
+ * Symmetric counterpart of HighPassMinusThreeDbAtCutoffWithButterworthQ - same -3 dB
+ * Butterworth shape at omega_c, same prewarp-drift tolerance.
+ */
+TEST(BiquadTest, LowPassMinusThreeDbAtCutoffWithButterworthQ) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kCutoffHz{2'000.0F};
+    constexpr float kCutoffMagnitudeTolerance{0.05F};
+
+    Biquad biquad{Biquad::lowPass(kCutoffHz, kSampleRate)};
+    const float peak{steadyStatePeak(biquad, kCutoffHz, kSampleRate)};
+
+    EXPECT_NEAR(peak, Biquad::BUTTERWORTH_Q, kCutoffMagnitudeTolerance);
+}
+
+/**
+ * @brief Pre-emphasis exhibits unity gain well below the shelf onset frequency.
+ *
+ * H(s) = (1 + s*tau) / (1 + s*tau/boost) approaches unity as omega -> 0. The shelf
+ * onset f_low = 1/(2*pi*tau) ~= 3.18 kHz for tau=50us; the 50 Hz test tone sits ~1.8
+ * decades below f_low - deep in the unity plateau. The 0.05 tolerance covers prewarp
+ * drift of the shelf onset.
+ */
+TEST(BiquadTest, PreEmphasisLowFrequencyPlateauIsUnity) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kTimeConstant{50e-6F};
+    constexpr float kSubShelfToneHz{50.0F};
+    constexpr float kPlateauTolerance{0.05F};
+
+    Biquad biquad{Biquad::preEmphasis(kTimeConstant, kSampleRate)};
+    const float peak{steadyStatePeak(biquad, kSubShelfToneHz, kSampleRate)};
+
+    EXPECT_NEAR(peak, 1.0F, kPlateauTolerance);
+}
+
+/**
+ * @brief Pre-emphasis at a high frequency rises towards the boost asymptote without crossing it.
+ *
+ * The analog prototype |H(jw)|^2 = (1 + (w*tau_z)^2) / (1 + (w*tau_p)^2) (tau_z=tau,
+ * tau_p=tau/boost) reaches the boost asymptote only as omega -> infinity; at finite f the
+ * magnitude sits below it. For tau=50us, fs=192 kHz, boost=16 the analog formula gives
+ * ~12 at 60 kHz; bilinear-transform warping brings the digital implementation to ~14,
+ * still under the 16 asymptote. Asserting peak > 0.75*boost AND peak < boost catches
+ * regressions in either factor (zero or pole) of the shelf transfer.
+ */
+TEST(BiquadTest, PreEmphasisHighFrequencyShelfRisesTowardsBoost) {
+    constexpr float kSampleRate{192'000.0F};
+    constexpr float kTimeConstant{50e-6F};
+    constexpr float kBoost{16.0F};
+    constexpr float kHighFrequencyToneHz{60'000.0F};
+    constexpr float kRiseLowerFraction{0.75F};
+
+    Biquad biquad{Biquad::preEmphasis(kTimeConstant, kSampleRate, kBoost)};
+    const float peak{steadyStatePeak(biquad, kHighFrequencyToneHz, kSampleRate)};
+
+    EXPECT_GT(peak, kBoost * kRiseLowerFraction);
+    EXPECT_LT(peak, kBoost);
+}
+
+/**
+ * @brief A non-default boost scales the pre-emphasis shelf plateau proportionally.
+ *
+ * Mirror of PreEmphasisHighFrequencyShelfRisesTowardsBoost with boost=4 instead of the
+ * default 16. Same 60 kHz tone, same 0.75*boost lower bound. If boost were ignored and
+ * always treated as 16, the measured peak would land near 14 - far outside (3, 4) -
+ * making the assertion fail. Pairs with the boost=16 single test to validate that the
+ * boost parameter is wired through preEmphasis() into the resulting transfer function.
+ */
+TEST(BiquadTest, PreEmphasisCustomBoostScalesShelfPlateau) {
+    constexpr float kSampleRate{192'000.0F};
+    constexpr float kTimeConstant{50e-6F};
+    constexpr float kCustomBoost{4.0F};
+    constexpr float kHighFrequencyToneHz{60'000.0F};
+    constexpr float kRiseLowerFraction{0.75F};
+
+    Biquad biquad{Biquad::preEmphasis(kTimeConstant, kSampleRate, kCustomBoost)};
+    const float peak{steadyStatePeak(biquad, kHighFrequencyToneHz, kSampleRate)};
+
+    EXPECT_GT(peak, kCustomBoost * kRiseLowerFraction);
+    EXPECT_LT(peak, kCustomBoost);
+}
+
+namespace {
+    struct BiquadFrequencyTestCase {
+        std::string_view name;
+        float cutoffHz;
+        float sampleRate;
+    };
+
+    /**
+     * @brief Render a BiquadFrequencyTestCase as its name plus the (cutoff, fs) pair
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const BiquadFrequencyTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {cutoff=" << testCase.cutoffHz << "Hz, fs=" << testCase.sampleRate << "Hz}";
+    }
+
+    /**
+     * @brief Cutoff/sample-rate pairs spanning telephony, broadcast, and high-rate audio
+     *        for the high-pass DC convergence sweep. All cutoffs sit safely above 0 so the
+     *        DC zero of the high-pass transfer remains analytically zero. The 48 kHz case
+     *        uses a different cutoff than the HighPassAttenuatesDc single test to avoid
+     *        re-validating the same operating point.
+     */
+    std::vector<BiquadFrequencyTestCase> makeHighPassDcTestCases() {
+        return {
+            BiquadFrequencyTestCase{"Cutoff50Fs8000", 50.0F, 8'000.0F},
+            BiquadFrequencyTestCase{"Cutoff300Fs44100", 300.0F, 44'100.0F},
+            BiquadFrequencyTestCase{"Cutoff100Fs48000", 100.0F, 48'000.0F},
+            BiquadFrequencyTestCase{"Cutoff1000Fs96000", 1'000.0F, 96'000.0F},
+            BiquadFrequencyTestCase{"Cutoff500Fs192000", 500.0F, 192'000.0F},
+        };
+    }
+
+    /**
+     * @brief Cutoff/sample-rate pairs for the low-pass DC pass-through sweep, with cutoffs
+     *        well above DC so the unity-gain plateau analytically applies at f=0. The 48
+     *        kHz case uses a different cutoff than the LowPassPassesDcCleanly single test
+     *        to avoid re-validating the same operating point.
+     */
+    std::vector<BiquadFrequencyTestCase> makeLowPassDcTestCases() {
+        return {
+            BiquadFrequencyTestCase{"Cutoff1000Fs8000", 1'000.0F, 8'000.0F},
+            BiquadFrequencyTestCase{"Cutoff3000Fs44100", 3'000.0F, 44'100.0F},
+            BiquadFrequencyTestCase{"Cutoff500Fs48000", 500.0F, 48'000.0F},
+            BiquadFrequencyTestCase{"Cutoff8000Fs96000", 8'000.0F, 96'000.0F},
+            BiquadFrequencyTestCase{"Cutoff10000Fs192000", 10'000.0F, 192'000.0F},
+        };
+    }
+}  // namespace
+
+class BiquadHighPassDcResponseTest : public ::testing::TestWithParam<BiquadFrequencyTestCase> {};
+
+/**
+ * @brief Across a cutoff/rate sweep, the high-pass biquad's DC output settles to zero.
+ *
+ * 8000 samples comfortably exceeds the IIR transient duration even for the slowest case
+ * (50 Hz cutoff at 8 kHz fs). The 1e-2 tolerance is loosened from the single-test 1e-3
+ * because the lowest-cutoff cases have measurable residual at a fixed sample budget.
+ */
+TEST_P(BiquadHighPassDcResponseTest, OutputConvergesToZero) {
+    constexpr int kSettleSamples{8000};
+    constexpr float kDcResidualTolerance{1e-2F};
+    const auto& testCase{GetParam()};
+
+    Biquad biquad{Biquad::highPass(testCase.cutoffHz, testCase.sampleRate)};
+
+    float lastOutput{0.0F};
+    for (int i{0}; i < kSettleSamples; ++i) {
+        lastOutput = biquad.process(1.0F);
+    }
+
+    EXPECT_NEAR(lastOutput, 0.0F, kDcResidualTolerance);
+}
+
+INSTANTIATE_TEST_SUITE_P(CornerRateMatrix, BiquadHighPassDcResponseTest, ::testing::ValuesIn(makeHighPassDcTestCases()),
+                         [](const ::testing::TestParamInfo<BiquadFrequencyTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+class BiquadLowPassDcResponseTest : public ::testing::TestWithParam<BiquadFrequencyTestCase> {};
+
+/**
+ * @brief Across a cutoff/rate sweep, the low-pass biquad's DC output settles to unity.
+ *
+ * Mirror of the high-pass DC sweep with expected value 1.0 - the LPF's unity-gain plateau
+ * at DC. Same warmup count and tolerance as the high-pass sweep.
+ */
+TEST_P(BiquadLowPassDcResponseTest, OutputSettlesAtUnity) {
+    constexpr int kSettleSamples{8000};
+    constexpr float kDcResidualTolerance{1e-2F};
+    const auto& testCase{GetParam()};
+
+    Biquad biquad{Biquad::lowPass(testCase.cutoffHz, testCase.sampleRate)};
+
+    float lastOutput{0.0F};
+    for (int i{0}; i < kSettleSamples; ++i) {
+        lastOutput = biquad.process(1.0F);
+    }
+
+    EXPECT_NEAR(lastOutput, 1.0F, kDcResidualTolerance);
+}
+
+INSTANTIATE_TEST_SUITE_P(CornerRateMatrix, BiquadLowPassDcResponseTest, ::testing::ValuesIn(makeLowPassDcTestCases()),
+                         [](const ::testing::TestParamInfo<BiquadFrequencyTestCase>& info) {
+                             return std::string{info.param.name};
+                         });
+
+namespace {
+    struct BiquadCustomQTestCase {
+        std::string_view name;
+        float q;
+    };
+
+    /**
+     * @brief Render a BiquadCustomQTestCase as its name plus the Q value
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const BiquadCustomQTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {q=" << testCase.q << "}";
+    }
+
+    /**
+     * @brief Q values spanning overdamped (0.5), neutral (1.0), and resonant (2.0, 4.0)
+     *        regimes for the LPF cutoff-magnitude sweep. The Butterworth Q (~0.7071) is
+     *        omitted to avoid duplicating LowPassMinusThreeDbAtCutoffWithButterworthQ.
+     */
+    std::vector<BiquadCustomQTestCase> makeCustomQTestCases() {
+        return {
+            BiquadCustomQTestCase{"Overdamped", 0.5F},
+            BiquadCustomQTestCase{"Unity", 1.0F},
+            BiquadCustomQTestCase{"MildPeak", 2.0F},
+            BiquadCustomQTestCase{"SharpPeak", 4.0F},
+        };
+    }
+}  // namespace
+
+class BiquadLowPassResonanceTest : public ::testing::TestWithParam<BiquadCustomQTestCase> {};
+
+/**
+ * @brief Across a Q sweep, the low-pass biquad's cutoff magnitude tracks Q.
+ *
+ * For a 2nd-order RBJ section at omega = omega_c, |H(jw_c)| = Q analytically (Q sets
+ * the height of the resonant peak). Ignoring q would collapse all cases to the
+ * Butterworth default (~0.707), failing every assertion outside that region. At
+ * fc=2000/fs=48000 (8.3% of Nyquist) the digital response stays within ~1% of analog
+ * Q across the sweep, so the 5% relative tolerance leaves ~5x slack at worst (Q=4).
+ */
+TEST_P(BiquadLowPassResonanceTest, CutoffMagnitudeMatchesQ) {
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kCutoffHz{2'000.0F};
+    constexpr float kRelativeTolerance{0.05F};
+    const auto& testCase{GetParam()};
+
+    Biquad biquad{Biquad::lowPass(kCutoffHz, kSampleRate, testCase.q)};
+    const float peak{steadyStatePeak(biquad, kCutoffHz, kSampleRate)};
+
+    EXPECT_NEAR(peak, testCase.q, testCase.q * kRelativeTolerance);
+}
+
+INSTANTIATE_TEST_SUITE_P(PoleQualitySweep, BiquadLowPassResonanceTest, ::testing::ValuesIn(makeCustomQTestCases()),
+                         [](const ::testing::TestParamInfo<BiquadCustomQTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/dsp/tests/test_hilbert.cpp
+++ b/src/utils/dsp/tests/test_hilbert.cpp
@@ -1,0 +1,229 @@
+/**
+ * @file test_hilbert.cpp
+ * @brief Unit tests for the Blackman-windowed Hilbert FIR transformer.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 05.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "hilbert.h"
+
+/**
+ * @brief Default-constructed Hilbert reports DEFAULT_TAPS via taps().
+ *
+ * Pinning the no-arg ctor to the public constant prevents accidental drift
+ * between the documented default and the in-code default-argument value.
+ */
+TEST(HilbertTest, DefaultTapCountMatchesPublicConstant) {
+    Hilbert hilbert{};
+
+    EXPECT_EQ(hilbert.taps(), Hilbert::DEFAULT_TAPS);
+}
+
+/**
+ * @brief Minimum valid tap count (3) constructs without throwing.
+ *
+ * Three is the lower bound of the valid domain (taps >= 3 and odd). Together
+ * with HilbertConstructorRejectionTest this pins the validation boundary on
+ * both sides.
+ */
+TEST(HilbertTest, AcceptsMinimumValidTapCount) {
+    EXPECT_NO_THROW(Hilbert{3});
+}
+
+/**
+ * @brief Impulse fed into Hilbert appears on the I channel exactly delay() samples later.
+ *
+ * I is a pure delay line matched to the FIR group delay on Q. Using taps=31
+ * (delay=15) keeps the test independent of DEFAULT_TAPS while remaining short
+ * enough to step through one sample at a time. Q-channel correctness is
+ * covered separately by QChannelImpulseResponseIsAntisymmetric (kernel
+ * structure) and EnvelopeStaysNearUnityForSteadyStateSinusoid (steady-state
+ * amplitude).
+ */
+TEST(HilbertTest, IChannelMatchesInputAfterGroupDelay) {
+    constexpr int kTaps{31};
+    Hilbert hilbert{kTaps};
+
+    const IqSample firstSample{hilbert.process(1.0F)};
+    EXPECT_FLOAT_EQ(firstSample.i, 0.0F);
+
+    for (int n{1}; n < hilbert.delay(); ++n) {
+        const IqSample intermediateSample{hilbert.process(0.0F)};
+        EXPECT_FLOAT_EQ(intermediateSample.i, 0.0F);
+    }
+    const IqSample atDelaySample{hilbert.process(0.0F)};
+
+    EXPECT_FLOAT_EQ(atDelaySample.i, 1.0F);
+}
+
+/**
+ * @brief Q-channel impulse response is antisymmetric around the center tap.
+ *
+ * The Blackman-windowed Hilbert FIR uses an antisymmetric kernel
+ * (coeffs[i] = -coeffs[taps-1-i]); feeding an impulse and reading kTaps
+ * samples reproduces the kernel in time order on the Q channel, so
+ * antisymmetry holds pair-wise and the center sample is exactly zero. The
+ * non-trivial-kernel check guards against a degenerate Q always returning 0
+ * (which would satisfy antisymmetry vacuously). The positive-sign check at
+ * k=+1 guards against a global sign flip antisymmetry is invariant to - the
+ * Hilbert kernel 2/(pi*k) gives positive coefficients at k>0.
+ *
+ * The 1e-6 antisymmetry tolerance leaves ~10x margin against the ~1e-7
+ * float roundoff expected for an antisymmetric coefficient pair derived
+ * from the same windowed-kernel formula.
+ */
+TEST(HilbertTest, QChannelImpulseResponseIsAntisymmetric) {
+    constexpr int kTaps{31};
+    constexpr float kAntisymmetryTolerance{1e-6F};
+    Hilbert hilbert{kTaps};
+
+    std::vector<float> qResponse;
+    qResponse.reserve(kTaps);
+
+    const IqSample firstSample{hilbert.process(1.0F)};
+    qResponse.push_back(firstSample.q);
+    for (int n{1}; n < kTaps; ++n) {
+        const IqSample sample{hilbert.process(0.0F)};
+        qResponse.push_back(sample.q);
+    }
+
+    for (int i{0}; i < kTaps / 2; ++i) {
+        EXPECT_NEAR(qResponse[i], -qResponse[kTaps - 1 - i], kAntisymmetryTolerance);
+    }
+    EXPECT_FLOAT_EQ(qResponse[kTaps / 2], 0.0F);
+    EXPECT_GT(qResponse[kTaps / 2 + 1], 0.0F);
+
+    EXPECT_TRUE(std::any_of(qResponse.cbegin(), qResponse.cend(), [](float qSample) { return qSample != 0.0F; }));
+}
+
+/**
+ * @brief A steady-state real sinusoid produces a unit-amplitude analytic envelope.
+ *
+ * For a real sin input the analytic Q approximates -cos(omega * n) within
+ * the FIR's passband, so |i + jq| = sqrt(sin^2 + cos^2) = 1 for a
+ * unit-amplitude tone. We warm the filter for kWarmupSamples = kTaps - the
+ * FIR has no IIR memory, so the buffer is fully primed after kTaps samples
+ * and subsequent output is in steady state.
+ *
+ * The 5e-4 tolerance was empirically calibrated against this 1 kHz / 48 kHz
+ * / 255-tap Blackman configuration: actual ripple peaks at ~1.45e-4 (max
+ * envelope rounds bit-exact to 1.0F; min sits near 0.99986). 5e-4 leaves
+ * ~3.5x slack against the measurement.
+ */
+TEST(HilbertTest, EnvelopeStaysNearUnityForSteadyStateSinusoid) {
+    constexpr int kTaps{255};
+    constexpr float kSampleRate{48'000.0F};
+    constexpr float kToneFrequency{1'000.0F};
+    constexpr float kOmega{2.0F * std::numbers::pi_v<float> * kToneFrequency / kSampleRate};
+    constexpr int kWarmupSamples{kTaps};
+    constexpr int kMeasureSamples{kTaps};
+    constexpr float kEnvelopeTolerance{5e-4F};
+
+    Hilbert hilbert{kTaps};
+
+    for (int n{0}; n < kWarmupSamples; ++n) {
+        [[maybe_unused]] const IqSample warmupSample{hilbert.process(std::sin(kOmega * static_cast<float>(n)))};
+    }
+
+    std::vector<float> magnitudes;
+    magnitudes.reserve(kMeasureSamples);
+    for (int n{kWarmupSamples}; n < kWarmupSamples + kMeasureSamples; ++n) {
+        const IqSample sample{hilbert.process(std::sin(kOmega * static_cast<float>(n)))};
+        magnitudes.push_back(std::hypot(sample.i, sample.q));
+    }
+
+    const auto [minMagnitude, maxMagnitude]{std::ranges::minmax(magnitudes)};
+
+    EXPECT_NEAR(maxMagnitude, 1.0F, kEnvelopeTolerance);
+    EXPECT_NEAR(minMagnitude, 1.0F, kEnvelopeTolerance);
+}
+
+/**
+ * @brief Zero input produces zero output on both channels for any number of samples.
+ *
+ * A linear FIR fed zeros holds zero output. We run for kZeroInputSamples =
+ * 3 * kTaps so the delay line cycles fully three times; accumulator drift
+ * or stale state on either channel would surface as a non-zero sample
+ * somewhere in the run.
+ */
+TEST(HilbertTest, ZeroInputProducesZeroOutput) {
+    constexpr int kTaps{31};
+    constexpr int kZeroInputSamples{kTaps * 3};
+
+    Hilbert hilbert{kTaps};
+
+    for (int n{0}; n < kZeroInputSamples; ++n) {
+        const IqSample sample{hilbert.process(0.0F)};
+        EXPECT_FLOAT_EQ(sample.i, 0.0F);
+        EXPECT_FLOAT_EQ(sample.q, 0.0F);
+    }
+}
+
+namespace {
+    /**
+     * @brief Tap counts the constructor must reject - sub-minimum (0, 1, 2) and even (4, 256).
+     */
+    std::vector<int> makeRejectedTapCounts() {
+        return {0, 1, 2, 4, 256};
+    }
+
+    /**
+     * @brief Valid odd tap counts spanning the boundary (3), small sizes, and production values.
+     */
+    std::vector<int> makeGeometryTapCounts() {
+        return {3, 5, 31, 127, 255, 511};
+    }
+}  // namespace
+
+class HilbertConstructorRejectionTest : public ::testing::TestWithParam<int> {};
+
+/**
+ * @brief Constructor throws std::invalid_argument for tap counts outside the valid domain.
+ *
+ * The valid domain is odd taps >= 3: counts below 3 leave too few samples
+ * for a centered FIR, even counts break the antisymmetry of the impulse
+ * response around the middle tap. Per-case parametrization isolates which
+ * sub-domain failed.
+ */
+TEST_P(HilbertConstructorRejectionTest, ThrowsInvalidArgumentForUnsupportedSize) {
+    const int taps{GetParam()};
+
+    EXPECT_THROW(Hilbert{taps}, std::invalid_argument);
+}
+
+INSTANTIATE_TEST_SUITE_P(OutOfDomain, HilbertConstructorRejectionTest, ::testing::ValuesIn(makeRejectedTapCounts()),
+                         [](const ::testing::TestParamInfo<int>& info) { return "Taps" + std::to_string(info.param); });
+
+class HilbertGeometryTest : public ::testing::TestWithParam<int> {};
+
+/**
+ * @brief taps() round-trips the constructor argument and delay() equals (taps-1)/2.
+ *
+ * The FIR is symmetric around its center tap, so the group delay is the
+ * half-width (taps - 1) / 2. The taps() check is a sanity assertion that
+ * the constructor accepted and stored the input. Integer arithmetic, no
+ * tolerance needed.
+ */
+TEST_P(HilbertGeometryTest, TapsAndDelayMatchInput) {
+    const int taps{GetParam()};
+    Hilbert hilbert{taps};
+
+    EXPECT_EQ(hilbert.taps(), taps);
+    EXPECT_EQ(hilbert.delay(), (taps - 1) / 2);
+}
+
+INSTANTIATE_TEST_SUITE_P(SizeSweep, HilbertGeometryTest, ::testing::ValuesIn(makeGeometryTapCounts()),
+                         [](const ::testing::TestParamInfo<int>& info) { return "Taps" + std::to_string(info.param); });

--- a/src/utils/dsp/tests/test_iq_sample.cpp
+++ b/src/utils/dsp/tests/test_iq_sample.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file test_iq_sample.cpp
+ * @brief Unit tests for the IqSample value type.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 05.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#include <gtest/gtest.h>
+
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "iq_sample.h"
+
+namespace {
+    struct IqSampleTestCase {
+        std::string_view name;
+        IqSample createdIqSample;
+        float expectedI;
+        float expectedQ;
+    };
+
+    /**
+     * @brief Render an IqSampleTestCase as its human-readable name and expected I/Q values
+     *        for gtest listings and failure messages.
+     */
+    void PrintTo(const IqSampleTestCase& testCase, std::ostream* os) {
+        *os << testCase.name << " {i=" << testCase.expectedI << ", q=" << testCase.expectedQ << "}";
+    }
+
+    /**
+     * @brief Build the parametric test cases covering IqSample construction variants.
+     */
+    std::vector<IqSampleTestCase> makeIqSampleTestCases() {
+        return {
+            IqSampleTestCase{"DefaultZeroes", IqSample{}, 0.0F, 0.0F},
+            IqSampleTestCase{"PositiveAndNegative", IqSample{.i = 0.25F, .q = -0.5F}, 0.25F, -0.5F},
+            IqSampleTestCase{"BothNegative", IqSample{.i = -0.125F, .q = -0.875F}, -0.125F, -0.875F},
+            IqSampleTestCase{
+                "HighPrecisionMixedSigns", IqSample{.i = 1.234567F, .q = -7.654321F}, 1.234567F, -7.654321F},
+            IqSampleTestCase{"WideMagnitudeRange", IqSample{.i = 1.0e-6F, .q = -1.0e3F}, 1.0e-6F, -1.0e3F},
+        };
+    }
+}  // namespace
+
+class IqSampleTest : public ::testing::TestWithParam<IqSampleTestCase> {};
+
+/**
+ * @brief Verify that the constructed IqSample carries the expected I/Q components.
+ */
+TEST_P(IqSampleTest, StoresProvidedComponents) {
+    const auto& testCase{GetParam()};
+
+    EXPECT_FLOAT_EQ(testCase.createdIqSample.i, testCase.expectedI);
+    EXPECT_FLOAT_EQ(testCase.createdIqSample.q, testCase.expectedQ);
+}
+
+INSTANTIATE_TEST_SUITE_P(ConstructionVariants, IqSampleTest, ::testing::ValuesIn(makeIqSampleTestCases()),
+                         [](const ::testing::TestParamInfo<IqSampleTestCase>& info) {
+                             return std::string{info.param.name};
+                         });

--- a/src/utils/tests/CMakeLists.txt
+++ b/src/utils/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Author: Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+# Date: 15.05.2026
+# License: GPL-3.0
+# Fork: https://github.com/IgrikXD/rpitx-ui
+# RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+
+# ----------------------------------------------------------
+# Shared test utility headers
+# ----------------------------------------------------------
+# Header-only library that exposes infrastructure shared across the unit-test
+# binaries: a gtest fixture-mixin that captures stdout / stderr for the
+# duration of a test (used by every test that asserts on user-visible
+# diagnostics). Test executables link this as an INTERFACE dep so the include
+# directory propagates without an artifact to link.
+# ----------------------------------------------------------
+add_library(rpitx_common_test_utils INTERFACE)
+target_include_directories(rpitx_common_test_utils INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/utils/tests/captured_streams_mixin.h
+++ b/src/utils/tests/captured_streams_mixin.h
@@ -1,0 +1,72 @@
+/**
+ * @file captured_streams_mixin.h
+ * @brief Reusable gtest mixin that captures stdout and stderr for the duration of a test.
+ *
+ * @author Ihar Yatsevich <igor.nikolaevich.96@gmail.com>
+ * @date 15.05.2026
+ * @copyright GPL-3.0
+ * @see https://github.com/IgrikXD/rpitx-ui
+ * @note RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+/**
+ * @brief Test-mixin that arms gtest's stdout/stderr capturers in SetUp and exposes
+ *        the captured text via lazy, cached accessors, releasing any unconsumed
+ *        capture in TearDown.
+ *
+ * Parameterized by the gtest fixture base (`::testing::Test` for non-parametric
+ * tests, `::testing::TestWithParam<T>` for value-parametrized ones) so the same
+ * capture behaviour plugs into either kind of fixture without code duplication.
+ * SetUp arms both captures unconditionally; the test body only pays the Get cost
+ * for the streams it actually queries via capturedStdout() / capturedStderr().
+ * The accessors cache on first call - gtest's API permits exactly one Get per
+ * Capture, and the cache turns subsequent calls into a reference read instead of
+ * a double-Get crash. TearDown releases any stream the body never consumed,
+ * keeping the process-global capture state clean for the next test even when a
+ * test bails out mid-body before reaching its stream assertions.
+ */
+template <typename Base>
+class CapturedStreamsMixin : public Base {
+protected:
+    void SetUp() override {
+        ::testing::internal::CaptureStdout();
+        ::testing::internal::CaptureStderr();
+    }
+
+    void TearDown() override {
+        if (stdoutConsumed_ == false) {
+            ::testing::internal::GetCapturedStdout();
+        }
+        if (stderrConsumed_ == false) {
+            ::testing::internal::GetCapturedStderr();
+        }
+    }
+
+    const std::string& capturedStdout() {
+        if (stdoutConsumed_ == false) {
+            cachedStdout_   = ::testing::internal::GetCapturedStdout();
+            stdoutConsumed_ = true;
+        }
+        return cachedStdout_;
+    }
+
+    const std::string& capturedStderr() {
+        if (stderrConsumed_ == false) {
+            cachedStderr_   = ::testing::internal::GetCapturedStderr();
+            stderrConsumed_ = true;
+        }
+        return cachedStderr_;
+    }
+
+private:
+    std::string cachedStdout_;
+    std::string cachedStderr_;
+    bool stdoutConsumed_{false};
+    bool stderrConsumed_{false};
+};

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,7 +7,7 @@
 # RF transmitter for Raspberry Pi with improved UI functionality, built with CMake.
 
 # rpitx-ui package version
-PACKAGE_VERSION='1.11'
+PACKAGE_VERSION='1.12'
 
 # Installed resource directory
 RESOURCE_INSTALL_DIR='/usr/share/rpitx-ui'


### PR DESCRIPTION
### Problem description

PR #44 introduced three new shared static libraries (`rpitx_dsp_utils`, `rpitx_audio_utils`, `rpitx_cli_utils`) and PR #45 migrated every transmitter binary to consume them, but the resulting code paths - the envelope-tracking AGC, the Butterworth / FM pre-emphasis biquads, the Blackman-windowed Hilbert FIR, the `libsndfile`-backed `AudioSource`, the streaming `AudioRateConverter` / `SoxrResampler`, the full `AudioPipeline`, and the CLI11 wrapper / frequency parser / reusable validators - had no automated coverage. Every regression had to surface on the Raspberry Pi at transmit time: hardware in front of you, antenna connected, root privileges to run the affected binary just to learn that an arithmetic edge case in a shared utility silently drifted. The same blind spot ran through `install.sh` (which promotes binaries to `/usr/bin` and then edits the Raspberry Pi boot config in one sequence) and CI (which executed that same install on an emulated Raspberry Pi OS arm64 image via [`pguyot/arm-runner-action`](https://github.com/pguyot/arm-runner-action)) - neither had any opportunity to catch a regression on the build host instead of on RF hardware.

#### `Agc::ENVELOPE_FLOOR` was an inline magic number

Inside `src/utils/dsp/agc.h` the envelope-floor clamp was the literal `1e-6f` written inline at the `updateGain` call site. Reproducing the literal in a boundary test would have created a silent dependency that drifts the moment the inline value is retuned. Promoting it to a public `static constexpr` member is the one production-source refactor that had to land before boundary tests could reference the threshold without that drift hazard.

### Fix description

#### Opt-in test-build infrastructure

- **CMakeLists.txt** (_root_): Added `option(ENABLE_TESTING "Build unit tests for the shared utility libraries" OFF)`. When `ON`, the root file calls `enable_testing()` and includes the new GoogleTest helper before `add_subdirectory(src)`. Production users running `install.sh` without the flag pay zero FetchContent cost - the option defaults to `OFF`.
- **cmake/googletest-build.cmake** (_new_): Pulls `google/googletest` at tag `v1.16.0` via `FetchContent`. Configured so `cmake --install` does not leak GoogleTest headers into `/usr`, with GoogleMock built alongside for the audio-pipeline interaction tests.
- **src/CMakeLists.txt** + **src/utils/CMakeLists.txt** (_new_): Replaced the three flat `add_subdirectory(utils/{dsp,audio,cli})` lines with a single aggregator that conditionally adds `src/utils/tests/` (shared test utilities) when `ENABLE_TESTING` is `ON`, then unconditionally adds the per-utility subdirectories. Each per-utility `CMakeLists.txt` gained an `if(ENABLE_TESTING) add_subdirectory(tests) endif()` block.

#### Shared test utilities

- **src/utils/tests/CMakeLists.txt** (_new_): Declares the `rpitx_common_test_utils` `INTERFACE` library exposing header-only test infrastructure via include-directory propagation.
- **src/utils/tests/captured_streams_mixin.h** (_new_): Template gtest fixture-mixin parameterized by either `::testing::Test` or `::testing::TestWithParam<T>`, capturing stdout / stderr in `SetUp`, exposing cached accessors, and cleaning up in `TearDown`.

#### Promotion of the AGC envelope floor to a public constant

- **src/utils/dsp/agc.h**: Promoted the inline `1e-6f` to `static constexpr float Agc::ENVELOPE_FLOOR{1e-6F}`. The call-site literal now reads `if (env_ > ENVELOPE_FLOOR)`, and the boundary tests reference the constant directly so the threshold cannot drift between the SUT and its tests.

#### DSP unit tests (`rpitx_dsp_utils_tests`)

- **src/utils/dsp/tests/test_iq_sample.cpp** (_new_): Parametric matrix over `IqSample` construction variants pinning bit-exact storage of the supplied components.
- **src/utils/dsp/tests/test_agc.cpp** (_new_): Coverage for `Agc`: floor-branch unity-gain return, IQ- / scalar-path output amplitude, no-NaN-on-zero-input, asymmetric attack/decay (fast rise, slow fall), and parametric magnitude sweeps verifying `gain = target / |magnitude|` above the floor and the unity clamp at-or-below it.
- **src/utils/dsp/tests/test_biquad.cpp** (_new_): Coverage for `Biquad` and its `highPass` / `lowPass` / `fmPreEmphasis` factories: pins `BUTTERWORTH_Q` against `1 / sqrt(2)`, the zero-input zero-output invariant of the Direct-Form-I state, the captured-impulse-response convolution match, and the steady-state magnitude response of each factory at points well above, well below, and around the cutoff.
- **src/utils/dsp/tests/test_hilbert.cpp** (_new_): Coverage for `Hilbert`: default tap count, validation boundary (min valid taps, rejection of even / too-small counts), zero-input zero-output, I-channel delay matches `delay()`, Q-channel impulse-response antisymmetry, and the steady-state `sqrt(I^2 + Q^2)` envelope staying near unity.

#### CLI unit tests (`rpitx_cli_utils_tests`)

- **src/utils/cli/tests/test_parse_frequency.cpp** (_new_): Parametric coverage for `parseFrequencyHz` - accept axis (integer, scientific in both `e` and `E`, decimal-mantissa scientific resolving to integer Hz, the `2^32` boundary, and the largest representable double strictly below `2^64`) and rejection axis (non-numeric, trailing unit, IEEE-754 `inf` / `nan`, non-positive, `2^64` overflow, fractional Hz).
- **src/utils/cli/tests/test_parse_cli_app.cpp** (_new_): Stdout / stderr routing contract for the CLI11 wrapper through `CapturedStreamsMixin`: silent-success, unknown-flag (routes `[ERROR]` + help banner to stderr), help-flag (banner to stdout, returns `ParseResult::Help`), and `assignFrequencyHz` round-trip success / failure with the `[ERROR] Invalid --freq '<input>'` diagnostic format and the out-variable-preservation invariant on the failure axis.
- **src/utils/cli/tests/test_validators.cpp** (_new_): Parametric coverage for `PositiveFiniteFloat` and `FrequencyHz` - accept-side notation classes and reject-side classes (non-numeric, incomplete scientific, IEEE-754 `inf` / `nan`, zero / negative magnitudes, plus the `FrequencyHz`-specific trailing-unit and fractional-Hz cases).

#### Audio unit tests (`rpitx_audio_utils_tests`)

- **src/utils/audio/tests/fake_audio_source.h** (_new_): In-memory `FakeAudioSource` for tests that need real samples flowing through the pipeline; mirrors the throw-on-misalignment contract of `LibsndfileAudioSource::read` so a misuse of the fake surfaces as a programmer error rather than a confusing short read.
- **src/utils/audio/tests/mock_audio_source.h** (_new_): GoogleMock-based `MockAudioSource` for behavioural tests - per-call return sequences, call-count expectations on `rewind()` under loop mode, partial-frame returns triggering the SUT's `std::logic_error` branch, and `StrictMock`-driven ctor-touch-surface assertions.
- **src/utils/audio/tests/test_audio_pipeline.cpp** (_new_): Coverage for `validateAudioFormat`, `validateLoopSupport`, and `AudioPipeline`. Pins both sides of each `validateAudioFormat` rejection branch (channel count, sample-rate range, branch-specific stderr diagnostic), the full `validateLoopSupport` truth table across seekable / non-seekable sources with `--loop` on / off, ctor invariants through a `StrictMock` (rejection of bad target rate / frame count / source format + assertion of the source-method touch surface), and an output-geometry matrix across channel-mode / source-channels combinations. The read-loop suite covers the two read-precondition guards (`std::invalid_argument` on a mismatched output span; `std::logic_error` on a partial-frame return), mono passthrough bit-exactness, stereo-to-mono downmix averaging, channel-preserve interleaving, sticky-error propagation (both via `error()` and after a positive read), and the loop-mode invariants (replay continuity, `rewind()` invocation on drain, error propagation when `rewind()` fails, and the livelock guard that returns `End` instead of looping forever on an empty seekable source). A parametric resample sweep drives non-trivial rate ratios through the full pipeline.
- **src/utils/audio/tests/test_audio_rate_converter.cpp** (_new_): Coverage for `AudioRateConverter`: passthrough geometry collapse, Bresenham accumulator's two-value alternation across many `process()` calls, passthrough sample-preservation, real rate-conversion success, `drain()` on both the passthrough fast path and after real conversion, `reset()` preserving the Bresenham accumulator across a loop boundary, and parametric ctor / `process()` rejection matrices.
- **src/utils/audio/tests/test_libsndfile_audio_source.cpp** (_new_): Writes ephemeral PCM_16 WAV fixtures across a mono / stereo × 44.1 kHz / 48 kHz matrix and drives `makeFileAudioSource` through format-reporting / successful-open invariants, `read()` contracts (normalized-float output, rejection of empty and non-channel-aligned destination spans), and `rewind()` restart. `MakeAudioSourceTest` covers the dispatcher delegating to the file factory when the stdin flag is off. The non-existent-path failure returns `nullptr` and emits the `[ERROR]`-prefixed stderr diagnostic.
- **src/utils/audio/tests/test_soxr_resampler.cpp** (_new_): Coverage for `SoxrResampler`: parametric rate-pair matrix (upsample, downsample, identity, 8 kHz -> 192 kHz extreme), every libsoxr quality preset, streaming behaviour (full-input consume when staged oversized; zero-consumed on empty flush), `clear()` semantics, move-construction / move-assignment invariants of the PIMPL-backed handle, and parametric ctor rejection of non-positive source / target rates.

#### Installation script integration

- **install.sh**: Added a `--enable-testing` flag that runs `ctest --output-on-failure` between `cmake --build` and `sudo cmake --install`. A failing test aborts the installation before any binary reaches `/usr/bin` and before the boot-config edit fires, with a tailored `[ERROR] Test execution failed - installation aborted!` banner and a new red `[ERROR]` color helper.
- Package-version bump `1.11` -> `1.12` in **CMakeLists.txt**, **install.sh**, **uninstall.sh**.

#### CI workflow integration

- **.github/workflows/rpitx-ui-build.yml**: Switched the install step to `./install.sh --enable-testing` so the full unit-test suite runs on every push and pull-request build, and updated the `::group::` banner to surface which mode the install ran in.

#### Documentation

- **README.md**: Added a paragraph under "_Installation process_" describing `--enable-testing` and naming the guarantee that "_a failing test aborts the installation before any binaries are installed system-wide or the Raspberry Pi boot configuration is modified_". Badge bumped to `1.12`.
